### PR TITLE
Only run with specific profiles set in a project property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,8 +74,13 @@
 			<artifactId>lambdaj</artifactId>
 			<version>2.3.3</version>
 		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.10</version>
 			<scope>test</scope>

--- a/src/main/java/com/lassekoskela/maven/BuildEventsExtension.java
+++ b/src/main/java/com/lassekoskela/maven/BuildEventsExtension.java
@@ -1,12 +1,16 @@
 package com.lassekoskela.maven;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import org.apache.maven.AbstractMavenLifecycleParticipant;
 import org.apache.maven.MavenExecutionException;
 import org.apache.maven.execution.ExecutionListener;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Profile;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
@@ -18,13 +22,16 @@ import com.lassekoskela.maven.logging.ConsoleLog;
 import com.lassekoskela.maven.logging.FileLog;
 import com.lassekoskela.maven.logging.Log;
 
+import static org.apache.commons.lang3.StringUtils.*;
+
 @Component(role = AbstractMavenLifecycleParticipant.class, hint = "buildevents")
 public class BuildEventsExtension extends AbstractMavenLifecycleParticipant {
 
 	static final String OUTPUT_MODE = "duration.output";
 	static final String OUTPUT_FILE = "duration.output.file";
 	static final String DEFAULT_FILE_DESTINATION = "target/durations.log";
-
+    static final String ACTIVATION_PROFILE_KEY = "maven-build-utils.activationProfiles";
+    
 	@Requirement
 	Logger logger;
 
@@ -32,10 +39,44 @@ public class BuildEventsExtension extends AbstractMavenLifecycleParticipant {
 	public void afterProjectsRead(MavenSession session)
 			throws MavenExecutionException {
 		Log log = resolveLogDestination(session);
-		BuildEventListener listener = createListener(log);
-		registerExecutionListener(session, listener);
-	}
 
+        if (!isActivationProfilesPropertySet(session))
+            log.info("Use " + ACTIVATION_PROFILE_KEY + " property to set in which profiles to run maven-build-utils.");
+
+        if (shouldBeActive(session)) {
+            BuildEventListener listener = createListener(log);
+            registerExecutionListener(session, listener);
+        }
+    }
+
+    private boolean shouldBeActive(MavenSession session) {
+        boolean shouldBeActive = false;
+
+        List<String> activationProfiles = listActivationProfiles(session);
+        for (String currentlyActive : getAllActiveProfileNames(session)) if (activationProfiles.contains(currentlyActive)) shouldBeActive = true;
+        return shouldBeActive;
+    }
+
+    protected List<String> listActivationProfiles(MavenSession session) {
+        return Arrays.asList(split(deleteWhitespace(getActivationProfilesProperty(session)), ','));
+    }
+    
+    protected static String getActivationProfilesProperty(MavenSession session) {
+        return session.getCurrentProject().getProperties().getProperty(ACTIVATION_PROFILE_KEY, "default");
+    }
+
+    protected static boolean isActivationProfilesPropertySet(MavenSession session) {
+        return !isBlank(session.getCurrentProject().getProperties().getProperty(ACTIVATION_PROFILE_KEY));
+    }
+
+    protected List<String> getAllActiveProfileNames(MavenSession session) {
+        List<String> names = new ArrayList<String>();
+        for (Profile profile : session.getCurrentProject().getActiveProfiles()) {
+            names.add(profile.getId());
+        }
+        return names;
+    }
+    
 	protected BuildEventListener createListener(Log log) {
 		return new BuildEventListener(new BuildEventLog(log));
 	}

--- a/src/test/java/com/lassekoskela/maven/BuildEventsExtensionTest.java
+++ b/src/test/java/com/lassekoskela/maven/BuildEventsExtensionTest.java
@@ -1,22 +1,24 @@
 package com.lassekoskela.maven;
 
-import static com.lassekoskela.maven.BuildEventsExtension.DEFAULT_FILE_DESTINATION;
-import static com.lassekoskela.maven.BuildEventsExtension.OUTPUT_FILE;
-import static com.lassekoskela.maven.BuildEventsExtension.OUTPUT_MODE;
+import static com.lassekoskela.maven.BuildEventsExtension.*;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Build;
+import org.apache.maven.model.Profile;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.logging.Logger;
 import org.junit.Before;
@@ -30,15 +32,20 @@ import com.lassekoskela.maven.logging.Log;
 public class BuildEventsExtensionTest {
 
 	private static final String BUILD_OUTPUT_DIR = "target";
+    private static final String ACTIVE_PROFILE_ID = "default";
+
 	private MavenSession session;
 	protected Log log;
 	private BuildEventsExtension extension;
-	private Properties properties;
-
+	private Properties userProperties;
+    private Properties projectProperties;
+    
 	@Before
 	public void setUp() throws Exception {
-		properties = new Properties();
-		session = createFakeMavenSession(properties);
+        userProperties = new Properties();
+        projectProperties = new Properties();
+        projectProperties.setProperty(ACTIVATION_PROFILE_KEY, "default");
+		session = createFakeMavenSession(userProperties, projectProperties);
 		extension = new BuildEventsExtension() {
 			@Override
 			protected BuildEventListener createListener(Log configuredLog) {
@@ -49,12 +56,11 @@ public class BuildEventsExtensionTest {
 		extension.logger = mock(Logger.class);
 	}
 
-	private MavenSession createFakeMavenSession(Properties properties) {
-		MavenProject project = createFakeMavenProject();
+	private MavenSession createFakeMavenSession(Properties userProperties, Properties projectProperties) {
+		MavenProject project = createFakeMavenProject(projectProperties);
 		MavenSession session = mock(MavenSession.class);
-		when(session.getUserProperties()).thenReturn(properties);
-		when(session.getRequest())
-				.thenReturn(mock(MavenExecutionRequest.class));
+		when(session.getUserProperties()).thenReturn(userProperties);
+		when(session.getRequest()).thenReturn(mock(MavenExecutionRequest.class));
 		when(session.getCurrentProject()).thenReturn(project);
 		when(session.getExecutionRootDirectory()).thenReturn(abspath("."));
 		return session;
@@ -68,11 +74,17 @@ public class BuildEventsExtensionTest {
 		}
 	}
 
-	private MavenProject createFakeMavenProject() {
+	private MavenProject createFakeMavenProject(Properties projectProperties) {
+        List<Profile> profiles = new ArrayList<Profile>();
+        Profile profile = mock(Profile.class);
+        profiles.add(profile);
+        when(profile.getId()).thenReturn(ACTIVE_PROFILE_ID);
 		MavenProject project = mock(MavenProject.class);
 		Build build = mock(Build.class);
 		when(project.getBuild()).thenReturn(build);
+        when(project.getProperties()).thenReturn(projectProperties);
 		when(build.getDirectory()).thenReturn(BUILD_OUTPUT_DIR);
+        when(project.getActiveProfiles()).thenReturn(profiles);
 		return project;
 	}
 
@@ -84,14 +96,14 @@ public class BuildEventsExtensionTest {
 
 	@Test
 	public void canBeExplicitlyToldToLogToConsole() throws Exception {
-		properties.setProperty(OUTPUT_MODE, "console");
+        userProperties.setProperty(OUTPUT_MODE, "console");
 		extension.afterProjectsRead(session);
 		assertThat(log, is(instanceOf(ConsoleLog.class)));
 	}
 
 	@Test
 	public void canBeToldToLogToDefaultFilesystemLocation() throws Exception {
-		properties.setProperty(OUTPUT_MODE, "file");
+		userProperties.setProperty(OUTPUT_MODE, "file");
 		extension.afterProjectsRead(session);
 		assertThat(log, is(instanceOf(FileLog.class)));
 		assertThat(log.destination(), is(abspath(DEFAULT_FILE_DESTINATION)));
@@ -99,8 +111,8 @@ public class BuildEventsExtensionTest {
 
 	@Test
 	public void canBeToldToLogToSpecificFilesystemLocation() throws Exception {
-		properties.setProperty(OUTPUT_MODE, "file");
-		properties.setProperty(OUTPUT_FILE, "tmp/whatever/specific.log");
+        userProperties.setProperty(OUTPUT_MODE, "file");
+		userProperties.setProperty(OUTPUT_FILE, "tmp/whatever/specific.log");
 		extension.afterProjectsRead(session);
 		assertThat(log, is(instanceOf(FileLog.class)));
 		assertThat(log.destination(), is(abspath("tmp/whatever/specific.log")));
@@ -108,9 +120,31 @@ public class BuildEventsExtensionTest {
 
 	@Test
 	public void invalidConfigurationDefaultsToConsole() throws Exception {
-		properties.setProperty(OUTPUT_MODE, "invalidValue");
+		userProperties.setProperty(OUTPUT_MODE, "invalidValue");
 		extension.afterProjectsRead(session);
 		assertThat(log, is(instanceOf(ConsoleLog.class)));
 		verify(extension.logger).error("Invalid configuration: invalidValue");
 	}
+
+    @Test
+   	public void doesntLogIfNoActivationProfileMatchesActiveProfiles() throws Exception {
+        projectProperties.setProperty(ACTIVATION_PROFILE_KEY, "someOtherProfile");
+   		extension.afterProjectsRead(session);
+   		assertNull(log);
+   	}
+
+    @Test
+   	public void doesntLogIfMultipleActivationProfilesButNoMatchingActiveProfiles() throws Exception {
+        projectProperties.setProperty(ACTIVATION_PROFILE_KEY, "some, other, thirdProfile");
+   		extension.afterProjectsRead(session);
+   		assertNull(log);
+   	}
+
+    @Test
+   	public void logWithMultipleActivationProfilesAndMatchingActiveProfile() throws Exception {
+        projectProperties.setProperty(ACTIVATION_PROFILE_KEY, "some, other, maybe, " + ACTIVE_PROFILE_ID);
+   		extension.afterProjectsRead(session);
+        assertThat(log, is(instanceOf(Log.class)));
+   	}
+
 }


### PR DESCRIPTION
You can now run the maven-build-utils only in certain profiles by setting:

```
<project>
...
<properties>
  <maven-build-utils.activationProfiles>thisProfile, thatProfile</maven-build-utils.activationProfiles>
</properties>
...
</project>
```

So with the above configuration, `maven-build-utils` will run only when either `thisProfile` or `thatProfile` is active during your build run.
