### PR TITLE
Timeline view of a build

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ to add to your project's POM:
                 <extension>
                     <groupId>com.github.lkoskela</groupId>
                     <artifactId>maven-build-utils</artifactId>
-                    <version>1.4</version>
+                    <version>1.5-SNAPSHOT</version>
                 </extension>
             </extensions>
         </build>
@@ -34,6 +34,9 @@ to add to your project's POM:
         <profiles>
             <profile>
                 <id>perfstats</id>
+                <properties>
+                	<maven-build-utils.activate-timeline>true</maven-build-utils.activate-timeline>
+                </properties>
             </profile>
         </profiles>
         ...
@@ -120,6 +123,13 @@ POM like so:
         </profile>
     </profiles>
 
+# TIMELINE
+
+If you have activated the timeline build with the propertiy "maven-build-utils.activate-timeline", 
+a html page is generated picturing a view of your build.
+
+    iceweasel timeline.html
+    
 # CONFIGURATION
 
 The report is written to the console by default. If you'd prefer to direct

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-all</artifactId>
-			<version>1.1</version>
+			<version>1.3</version>
 		</dependency>
 		<dependency>
 			<groupId>com.googlecode.lambdaj</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,17 @@
 			<artifactId>guava</artifactId>
 			<version>14.0.1</version>
 		</dependency>
+		<dependency>
+			<groupId>com.github.spullara.mustache.java</groupId>
+			<artifactId>compiler</artifactId>
+			<version>0.8.12</version>
+		</dependency>
+		<dependency>
+			<groupId>xmlunit</groupId>
+			<artifactId>xmlunit</artifactId>
+			<scope>compile</scope>
+			<version>1.4</version>
+		</dependency>
 	</dependencies>
 	<reporting>
 		<plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-all</artifactId>
-			<version>1.9.0</version>
+			<version>1.9.5</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,30 @@
 			</properties>
 		</developer>
 	</developers>
+	<contributors>
+		<contributor>
+			<name>Thomas Hilaire</name>
+			<email>thilaire@linagora.com</email>
+			<url>https://github.com/thomas-hilaire</url>
+			<organization>Linagora</organization>
+			<organizationUrl>http://linagora.com</organizationUrl>
+			<roles>
+				<role>developer</role>
+			</roles>
+			<timezone>Europe/Paris</timezone>
+		</contributor>
+		<contributor>
+			<name>Antoine Duprat</name>
+			<email>aduprat@linagora.com</email>
+			<url>https://github.com/aduprat</url>
+			<organization>Linagora</organization>
+			<organizationUrl>http://linagora.com</organizationUrl>
+			<roles>
+				<role>developer</role>
+			</roles>
+			<timezone>Europe/Paris</timezone>
+		</contributor>
+	</contributors>
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.maven</groupId>

--- a/src/main/java/com/lassekoskela/maven/BuildTimelineExtension.java
+++ b/src/main/java/com/lassekoskela/maven/BuildTimelineExtension.java
@@ -1,0 +1,29 @@
+package com.lassekoskela.maven;
+
+import org.apache.maven.AbstractMavenLifecycleParticipant;
+import org.apache.maven.MavenExecutionException;
+import org.apache.maven.execution.MavenSession;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.codehaus.plexus.logging.Logger;
+
+import com.lassekoskela.maven.timeline.BuildTimelineListener;
+
+@Component(role = AbstractMavenLifecycleParticipant.class, hint = "buildtimeline")
+public class BuildTimelineExtension extends MavenExtension {
+
+    static final String ACTIVATION_PROPERTY_KEY = "maven-build-utils.activate-timeline";
+    static final String ACTIVATION_PROFILE_KEY = "maven-build-utils.activationTimelineProfiles";
+    
+	@Requirement
+	Logger logger;
+
+	@Override
+	public void afterProjectsRead(MavenSession session)
+			throws MavenExecutionException {
+
+        if (shouldBeActive(session, ACTIVATION_PROPERTY_KEY, ACTIVATION_PROFILE_KEY)) {
+            registerExecutionListener(session, new BuildTimelineListener(logger));
+        }
+    }
+}

--- a/src/main/java/com/lassekoskela/maven/MavenExtension.java
+++ b/src/main/java/com/lassekoskela/maven/MavenExtension.java
@@ -1,0 +1,74 @@
+package com.lassekoskela.maven;
+
+import static org.apache.commons.lang3.StringUtils.deleteWhitespace;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.split;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.maven.AbstractMavenLifecycleParticipant;
+import org.apache.maven.execution.ExecutionListener;
+import org.apache.maven.execution.MavenExecutionRequest;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Profile;
+
+import com.lassekoskela.maven.buildevents.BuildEventListener;
+import com.lassekoskela.maven.buildevents.BuildEventLog;
+import com.lassekoskela.maven.buildevents.ExecutionListenerChain;
+import com.lassekoskela.maven.logging.Log;
+
+public class MavenExtension extends AbstractMavenLifecycleParticipant {
+
+    public boolean shouldBeActive(MavenSession session, String activationPropertyKey, String activationProfileKey) {
+        boolean shouldBeActive = Boolean.valueOf(getActivationProperty(session, activationPropertyKey));
+        if (shouldBeActive) {
+        	return shouldBeActive;
+        }
+
+        List<String> activationProfiles = listActivationProfiles(session, activationProfileKey);
+        for (String currentlyActive : getAllActiveProfileNames(session)) if (activationProfiles.contains(currentlyActive)) shouldBeActive = true;
+        return shouldBeActive;
+    }
+
+    protected List<String> listActivationProfiles(MavenSession session, String activationProfileKey) {
+        return Arrays.asList(split(deleteWhitespace(getActivationProfilesProperty(session, activationProfileKey)), ','));
+    }
+    
+    protected static String getActivationProfilesProperty(MavenSession session, String activationProfileKey) {
+        return session.getCurrentProject().getProperties().getProperty(activationProfileKey, "default");
+    }
+
+    
+    private String getActivationProperty(MavenSession session, String activationPropertyKey) {
+        return session.getCurrentProject().getProperties().getProperty(activationPropertyKey, Boolean.FALSE.toString());
+    }
+
+    public boolean isActivationProfilesPropertySet(MavenSession session, String activationProfileKey) {
+        return !isBlank(session.getCurrentProject().getProperties().getProperty(activationProfileKey));
+    }
+
+    protected List<String> getAllActiveProfileNames(MavenSession session) {
+        List<String> names = new ArrayList<String>();
+        for (Profile profile : session.getCurrentProject().getActiveProfiles()) {
+            names.add(profile.getId());
+        }
+        return names;
+    }
+    
+	protected BuildEventListener createListener(Log log) {
+		return new BuildEventListener(new BuildEventLog(log));
+	}
+
+	public String getProperty(MavenSession s, String key, String defaultValue) {
+		return s.getUserProperties().getProperty(key, defaultValue);
+	}
+
+	protected void registerExecutionListener(MavenSession session, ExecutionListener listener) {
+		MavenExecutionRequest request = session.getRequest();
+		ExecutionListener original = request.getExecutionListener();
+		ExecutionListener chain = new ExecutionListenerChain(original, listener);
+		request.setExecutionListener(chain);
+	}
+}

--- a/src/main/java/com/lassekoskela/maven/bean/Goal.java
+++ b/src/main/java/com/lassekoskela/maven/bean/Goal.java
@@ -1,29 +1,41 @@
 package com.lassekoskela.maven.bean;
 
+import com.google.common.base.Objects;
+import com.google.common.base.Objects.ToStringHelper;
 import com.lassekoskela.time.Duration;
 
 
 public class Goal extends MavenItem {
 
-	public Goal(String name, Duration duration) {
+	private final long startTimeInMs;
+
+	public Goal(String name, Duration duration, long startTimeInMs) {
 		super(name, duration);
+		this.startTimeInMs = startTimeInMs;
+	}
+
+	public long getStartTimeInMs() {
+		return startTimeInMs;
 	}
 
 	@Override
 	public final int hashCode(){
-		return super.hashCode();
+		return Objects.hashCode(super.hashCode(), startTimeInMs);
 	}
 	
 	@Override
 	public final boolean equals(Object object){
 		if (object instanceof Goal) {
-			return super.equals(object);
+			Goal that = (Goal) object;
+			return super.equals(object)
+				&& Objects.equal(this.startTimeInMs, that.startTimeInMs);
 		}
 		return false;
 	}
 
 	@Override
-	public String toString() {
-		return super.toString();
+	public ToStringHelper toStringHelper() {
+		return super.toStringHelper()
+			.add("startTimeInMs", startTimeInMs);
 	}
 }

--- a/src/main/java/com/lassekoskela/maven/bean/Goal.java
+++ b/src/main/java/com/lassekoskela/maven/bean/Goal.java
@@ -1,5 +1,8 @@
 package com.lassekoskela.maven.bean;
 
+import java.util.Set;
+
+import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 import com.google.common.base.Objects.ToStringHelper;
 import com.lassekoskela.time.Duration;
@@ -8,12 +11,14 @@ import com.lassekoskela.time.Duration;
 public class Goal extends MavenItem {
 
 	private final long startTimeInMs;
+	private final Set<String> dependencies;
 	private Duration duration;
 
-	public Goal(String name, Duration duration, long startTimeInMs) {
+	public Goal(String name, Duration duration, long startTimeInMs, Set<String> dependencies) {
 		super(name);
 		this.duration = duration;
 		this.startTimeInMs = startTimeInMs;
+		this.dependencies = dependencies;
 	}
 
 	public long getStartTimeInMs() {
@@ -27,10 +32,22 @@ public class Goal extends MavenItem {
 	public void setDuration(Duration duration) {
 		this.duration = duration;
 	}
+	
+	public Set<String> getDependencies() {
+		return dependencies;
+	}
+	
+	public String serializeDependencies() {
+		return Joiner.on(' ').join(dependencies);
+	}
+
+	public long getCompletedTimeInMs() {
+		return startTimeInMs + getDuration().inMillis();
+	}
 
 	@Override
 	public final int hashCode(){
-		return Objects.hashCode(super.hashCode(), duration, startTimeInMs);
+		return Objects.hashCode(super.hashCode(), duration, startTimeInMs, dependencies);
 	}
 	
 	@Override
@@ -39,7 +56,8 @@ public class Goal extends MavenItem {
 			Goal that = (Goal) object;
 			return super.equals(object)
 				&& Objects.equal(this.duration, that.duration)
-				&& Objects.equal(this.startTimeInMs, that.startTimeInMs);
+				&& Objects.equal(this.startTimeInMs, that.startTimeInMs)
+				&& Objects.equal(this.dependencies, that.dependencies);
 		}
 		return false;
 	}
@@ -48,6 +66,7 @@ public class Goal extends MavenItem {
 	public ToStringHelper toStringHelper() {
 		return super.toStringHelper()
 			.add("duration", duration)
-			.add("startTimeInMs", startTimeInMs);
+			.add("startTimeInMs", startTimeInMs)
+			.add("dependencies", dependencies);
 	}
 }

--- a/src/main/java/com/lassekoskela/maven/bean/Goal.java
+++ b/src/main/java/com/lassekoskela/maven/bean/Goal.java
@@ -8,9 +8,11 @@ import com.lassekoskela.time.Duration;
 public class Goal extends MavenItem {
 
 	private final long startTimeInMs;
+	private Duration duration;
 
 	public Goal(String name, Duration duration, long startTimeInMs) {
-		super(name, duration);
+		super(name);
+		this.duration = duration;
 		this.startTimeInMs = startTimeInMs;
 	}
 
@@ -18,9 +20,17 @@ public class Goal extends MavenItem {
 		return startTimeInMs;
 	}
 
+	public Duration getDuration() {
+		return duration;
+	}
+
+	public void setDuration(Duration duration) {
+		this.duration = duration;
+	}
+
 	@Override
 	public final int hashCode(){
-		return Objects.hashCode(super.hashCode(), startTimeInMs);
+		return Objects.hashCode(super.hashCode(), duration, startTimeInMs);
 	}
 	
 	@Override
@@ -28,6 +38,7 @@ public class Goal extends MavenItem {
 		if (object instanceof Goal) {
 			Goal that = (Goal) object;
 			return super.equals(object)
+				&& Objects.equal(this.duration, that.duration)
 				&& Objects.equal(this.startTimeInMs, that.startTimeInMs);
 		}
 		return false;
@@ -36,6 +47,7 @@ public class Goal extends MavenItem {
 	@Override
 	public ToStringHelper toStringHelper() {
 		return super.toStringHelper()
+			.add("duration", duration)
 			.add("startTimeInMs", startTimeInMs);
 	}
 }

--- a/src/main/java/com/lassekoskela/maven/bean/MavenItem.java
+++ b/src/main/java/com/lassekoskela/maven/bean/MavenItem.java
@@ -39,7 +39,7 @@ public class MavenItem {
 
 	@Override
 	public String toString() {
-		return toString()
+		return toStringHelper()
 			.toString();
 	}
 	

--- a/src/main/java/com/lassekoskela/maven/bean/MavenItem.java
+++ b/src/main/java/com/lassekoskela/maven/bean/MavenItem.java
@@ -2,37 +2,29 @@ package com.lassekoskela.maven.bean;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Objects.ToStringHelper;
-import com.lassekoskela.time.Duration;
 
 public class MavenItem {
 
 	private final String name;
-	private final Duration duration;
 	
-	public MavenItem(String name, Duration duration) {
+	public MavenItem(String name) {
 		this.name = name;
-		this.duration = duration;
 	}
 	
 	public String getItemId() {
 		return name;
 	}
-	
-	public Duration getDuration() {
-		return duration;
-	}
 
 	@Override
 	public int hashCode(){
-		return Objects.hashCode(name, duration);
+		return Objects.hashCode(name);
 	}
 	
 	@Override
 	public boolean equals(Object object){
 		if (object instanceof MavenItem) {
 			MavenItem that = (MavenItem) object;
-			return Objects.equal(this.name, that.name)
-				&& Objects.equal(this.duration, that.duration);
+			return Objects.equal(this.name, that.name);
 		}
 		return false;
 	}
@@ -45,7 +37,6 @@ public class MavenItem {
 	
 	protected ToStringHelper toStringHelper() {
 		return Objects.toStringHelper(this)
-			.add("name", name)
-			.add("duration", duration);
+			.add("name", name);
 	}
 }

--- a/src/main/java/com/lassekoskela/maven/bean/Phase.java
+++ b/src/main/java/com/lassekoskela/maven/bean/Phase.java
@@ -4,6 +4,9 @@ import java.util.Set;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Objects.ToStringHelper;
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
 
 public class Phase extends MavenItem {
 
@@ -20,6 +23,17 @@ public class Phase extends MavenItem {
 	
 	public void addGoal(Goal goal) {
 		goals.add(goal);
+	}
+
+	public Optional<Goal> getGoal(final String goalName) {
+		return FluentIterable
+				.from(goals)
+				.firstMatch(new Predicate<Goal>() {
+					@Override
+					public boolean apply(Goal input) {
+						return input.getItemId().equals(goalName);
+					}
+				});
 	}
 
 	@Override

--- a/src/main/java/com/lassekoskela/maven/bean/Phase.java
+++ b/src/main/java/com/lassekoskela/maven/bean/Phase.java
@@ -4,14 +4,13 @@ import java.util.Set;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Objects.ToStringHelper;
-import com.lassekoskela.time.Duration;
 
 public class Phase extends MavenItem {
 
 	private final Set<Goal> goals;
 	
-	public Phase(String name, Duration duration, Set<Goal> goals) {
-		super(name, duration);
+	public Phase(String name, Set<Goal> goals) {
+		super(name);
 		this.goals = goals;
 	}
 	

--- a/src/main/java/com/lassekoskela/maven/bean/Project.java
+++ b/src/main/java/com/lassekoskela/maven/bean/Project.java
@@ -4,6 +4,9 @@ import java.util.Set;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Objects.ToStringHelper;
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
 
 public class Project extends MavenItem {
 
@@ -18,8 +21,20 @@ public class Project extends MavenItem {
 		return phases;
 	}
 	
-	public void addPhase(Phase phase) {
+	public Phase addPhase(Phase phase) {
 		phases.add(phase);
+		return phase;
+	}
+
+	public Optional<Phase> getPhase(final String phaseName) {
+		return FluentIterable
+				.from(phases)
+				.firstMatch(new Predicate<Phase>() {
+					@Override
+					public boolean apply(Phase input) {
+						return input.getItemId().equals(phaseName);
+					}
+				});
 	}
 
 	@Override

--- a/src/main/java/com/lassekoskela/maven/bean/Project.java
+++ b/src/main/java/com/lassekoskela/maven/bean/Project.java
@@ -4,14 +4,13 @@ import java.util.Set;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Objects.ToStringHelper;
-import com.lassekoskela.time.Duration;
 
 public class Project extends MavenItem {
 
 	private final Set<Phase> phases;
 	
-	public Project(String name, Duration duration, Set<Phase> phases) {
-		super(name, duration);
+	public Project(String name, Set<Phase> phases) {
+		super(name);
 		this.phases = phases;
 	}
 	

--- a/src/main/java/com/lassekoskela/maven/bean/Timeline.java
+++ b/src/main/java/com/lassekoskela/maven/bean/Timeline.java
@@ -1,25 +1,19 @@
 package com.lassekoskela.maven.bean;
 
-import java.util.Set;
-
 import com.google.common.base.Objects;
 
 public class Timeline {
 
-	private final Set<Project> projects;
+	private final Iterable<Project> projects;
 	
-	public Timeline(Set<Project> projects) {
+	public Timeline(Iterable<Project> projects) {
 		this.projects = projects;
 	}
 	
-	public Set<Project> getProjects() {
+	public Iterable<Project> getProjects() {
 		return projects;
 	}
 	
-	public void addProject(Project project) {
-		projects.add(project);
-	}
-
 	@Override
 	public int hashCode(){
 		return Objects.hashCode(projects);

--- a/src/main/java/com/lassekoskela/maven/timeline/BuildTimelineListener.java
+++ b/src/main/java/com/lassekoskela/maven/timeline/BuildTimelineListener.java
@@ -1,0 +1,124 @@
+package com.lassekoskela.maven.timeline;
+
+import java.io.FileNotFoundException;
+import java.util.Map;
+
+import org.apache.maven.execution.AbstractExecutionListener;
+import org.apache.maven.execution.ExecutionEvent;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.logging.Logger;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.lassekoskela.maven.bean.Goal;
+import com.lassekoskela.maven.bean.Phase;
+import com.lassekoskela.maven.bean.Project;
+import com.lassekoskela.maven.bean.Timeline;
+import com.lassekoskela.time.DateProvider;
+import com.lassekoskela.time.DateProviderImpl;
+import com.lassekoskela.time.Duration;
+
+public class BuildTimelineListener extends AbstractExecutionListener {
+
+	private final Logger logger;
+	private final DateProvider dateProvider;
+	@VisibleForTesting final Map<String, Project> nameToProjectMapping;
+	@VisibleForTesting final Map<String, Goal> nameToGoalMapping;
+	
+	public BuildTimelineListener(Logger logger) {
+		this(logger, new DateProviderImpl());
+	}
+	
+	public BuildTimelineListener(Logger logger, DateProvider dateProvider) {
+		this.logger = logger;
+		this.dateProvider = dateProvider;
+		this.nameToProjectMapping = Maps.newHashMap();
+		this.nameToGoalMapping = Maps.newHashMap();
+	}
+
+	@Override
+	public void sessionEnded(ExecutionEvent event) {
+		try {
+			new Exporter(logger).export(new Timeline(nameToProjectMapping.values()));
+		} catch (TimelineExportException e) {
+			Throwables.propagate(e);
+		} catch (FileNotFoundException e) {
+			Throwables.propagate(e);
+		}
+	}
+
+	@Override
+	public void mojoStarted(ExecutionEvent event) {
+		Project project = projectOfMojo(event.getProject().getArtifactId());
+		Phase phase = phaseOfMojo(event.getMojoExecution().getLifecyclePhase(), project);
+		mojoStarted(event, project, phase);
+	}
+	
+	@Override
+	public void mojoSucceeded(ExecutionEvent event) {
+		mojoEnded(event);
+	}
+
+	@Override
+	public void mojoFailed(ExecutionEvent event) {
+		mojoEnded(event);
+	}
+
+	@VisibleForTesting void mojoEnded(ExecutionEvent event) {
+		Goal endedGoal = nameToGoalMapping.get(event.getMojoExecution().getGoal());
+		endedGoal.setDuration(new Duration(relativeNowFromBuildStartTime(event) - endedGoal.getStartTimeInMs()));
+		logger.info(String.format("[Timeline] The Goal[%s:%s:%s] started at [%dms] has finished at [%dms], elapsed[%dms]",
+				event.getMojoExecution().getArtifactId(),
+				event.getMojoExecution().getLifecyclePhase(), endedGoal.getItemId(), endedGoal.getStartTimeInMs(),
+				endedGoal.getCompletedTimeInMs(), endedGoal.getDuration().inMillis()));
+	}
+
+	@VisibleForTesting void mojoStarted(ExecutionEvent event, Project project, Phase phase) {
+		String goalName = event.getMojoExecution().getGoal();
+		if (!phase.getGoal(goalName).isPresent()) {
+			goalStarted(event, project, phase, goalName);
+		} else {
+			logger.info(String.format("[Timeline] A Goal seems to be started twice in (%s:%s) %s",
+					project.getItemId(), phase.getItemId(), goalName));
+		}
+	}
+
+	@VisibleForTesting void goalStarted(ExecutionEvent event, Project project, Phase phase, String goalName) {
+		long buildStartTimeInMs = relativeNowFromBuildStartTime(event);
+		Goal newGoal = new Goal(goalName, new Duration(0), buildStartTimeInMs, Sets.<String>newHashSet());
+		phase.addGoal(newGoal);
+		nameToGoalMapping.put(goalName, newGoal);
+
+		logger.info(String.format("[Timeline] Add a new Goal[%s:%s:%s] started at [%dms]",
+				project.getItemId(), phase.getItemId(), goalName, buildStartTimeInMs));
+	}
+
+	@VisibleForTesting Phase phaseOfMojo(String phaseName, Project project) {
+		Optional<Phase> phase = project.getPhase(phaseName);
+		if (!phase.isPresent()) {
+			logger.info(String.format("[Timeline] Add a new Phase[%s:%s]", project.getItemId(), phaseName));
+			return project.addPhase(new Phase(phaseName, Sets.<Goal>newHashSet()));
+		}
+		return phase.get();
+	}
+
+	@VisibleForTesting Project projectOfMojo(String projectName) {
+		if (!nameToProjectMapping.containsKey(projectName)) {
+			logger.info("[Timeline] Add a new Project[" + projectName + "]");
+			nameToProjectMapping.put(projectName, new Project(projectName, Sets.<Phase>newHashSet()));
+		}
+		return nameToProjectMapping.get(projectName);
+	}
+
+	@VisibleForTesting long relativeNowFromBuildStartTime(ExecutionEvent event) {
+		long elapsedTime = dateProvider.now().getTime() - event.getSession().getStartTime().getTime();
+		if (elapsedTime < 0) {
+			throw new TimelineExportException("Relative time is negative");
+		}
+		return elapsedTime;
+	}
+
+}

--- a/src/main/java/com/lassekoskela/maven/timeline/BuildTimelineListener.java
+++ b/src/main/java/com/lassekoskela/maven/timeline/BuildTimelineListener.java
@@ -5,7 +5,6 @@ import java.util.Map;
 
 import org.apache.maven.execution.AbstractExecutionListener;
 import org.apache.maven.execution.ExecutionEvent;
-import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.logging.Logger;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -70,7 +69,7 @@ public class BuildTimelineListener extends AbstractExecutionListener {
 	@VisibleForTesting void mojoEnded(ExecutionEvent event) {
 		Goal endedGoal = nameToGoalMapping.get(event.getMojoExecution().getGoal());
 		endedGoal.setDuration(new Duration(relativeNowFromBuildStartTime(event) - endedGoal.getStartTimeInMs()));
-		logger.info(String.format("[Timeline] The Goal[%s:%s:%s] started at [%dms] has finished at [%dms], elapsed[%dms]",
+		logger.debug(String.format("[Timeline] The Goal[%s:%s:%s] started at [%dms] has finished at [%dms], elapsed[%dms]",
 				event.getMojoExecution().getArtifactId(),
 				event.getMojoExecution().getLifecyclePhase(), endedGoal.getItemId(), endedGoal.getStartTimeInMs(),
 				endedGoal.getCompletedTimeInMs(), endedGoal.getDuration().inMillis()));
@@ -81,7 +80,7 @@ public class BuildTimelineListener extends AbstractExecutionListener {
 		if (!phase.getGoal(goalName).isPresent()) {
 			goalStarted(event, project, phase, goalName);
 		} else {
-			logger.info(String.format("[Timeline] A Goal seems to be started twice in (%s:%s) %s",
+			logger.debug(String.format("[Timeline] A Goal seems to be started twice in (%s:%s) %s",
 					project.getItemId(), phase.getItemId(), goalName));
 		}
 	}
@@ -92,14 +91,14 @@ public class BuildTimelineListener extends AbstractExecutionListener {
 		phase.addGoal(newGoal);
 		nameToGoalMapping.put(goalName, newGoal);
 
-		logger.info(String.format("[Timeline] Add a new Goal[%s:%s:%s] started at [%dms]",
+		logger.debug(String.format("[Timeline] Add a new Goal[%s:%s:%s] started at [%dms]",
 				project.getItemId(), phase.getItemId(), goalName, buildStartTimeInMs));
 	}
 
 	@VisibleForTesting Phase phaseOfMojo(String phaseName, Project project) {
 		Optional<Phase> phase = project.getPhase(phaseName);
 		if (!phase.isPresent()) {
-			logger.info(String.format("[Timeline] Add a new Phase[%s:%s]", project.getItemId(), phaseName));
+			logger.debug(String.format("[Timeline] Add a new Phase[%s:%s]", project.getItemId(), phaseName));
 			return project.addPhase(new Phase(phaseName, Sets.<Goal>newHashSet()));
 		}
 		return phase.get();
@@ -107,7 +106,7 @@ public class BuildTimelineListener extends AbstractExecutionListener {
 
 	@VisibleForTesting Project projectOfMojo(String projectName) {
 		if (!nameToProjectMapping.containsKey(projectName)) {
-			logger.info("[Timeline] Add a new Project[" + projectName + "]");
+			logger.debug("[Timeline] Add a new Project[" + projectName + "]");
 			nameToProjectMapping.put(projectName, new Project(projectName, Sets.<Phase>newHashSet()));
 		}
 		return nameToProjectMapping.get(projectName);

--- a/src/main/java/com/lassekoskela/maven/timeline/Exporter.java
+++ b/src/main/java/com/lassekoskela/maven/timeline/Exporter.java
@@ -1,34 +1,3 @@
-/* ***** BEGIN LICENSE BLOCK *****
- * 
- * Copyright (C) 2011-2012  Linagora
- *
- * This program is free software: you can redistribute it and/or 
- * modify it under the terms of the GNU Affero General Public License as 
- * published by the Free Software Foundation, either version 3 of the 
- * License, or (at your option) any later version, provided you comply 
- * with the Additional Terms applicable for OBM connector by Linagora 
- * pursuant to Section 7 of the GNU Affero General Public License, 
- * subsections (b), (c), and (e), pursuant to which you must notably (i) retain 
- * the “Message sent thanks to OBM, Free Communication by Linagora” 
- * signature notice appended to any and all outbound messages 
- * (notably e-mail and meeting requests), (ii) retain all hypertext links between 
- * OBM and obm.org, as well as between Linagora and linagora.com, and (iii) refrain 
- * from infringing Linagora intellectual property rights over its trademarks 
- * and commercial brands. Other Additional Terms apply, 
- * see <http://www.linagora.com/licenses/> for more details. 
- *
- * This program is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
- * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License 
- * for more details. 
- *
- * You should have received a copy of the GNU Affero General Public License 
- * and its applicable Additional Terms for OBM along with this program. If not, 
- * see <http://www.gnu.org/licenses/> for the GNU Affero General Public License version 3 
- * and <http://www.linagora.com/licenses/> for the Additional Terms applicable to 
- * OBM connectors. 
- * 
- * ***** END LICENSE BLOCK ***** */
 package com.lassekoskela.maven.timeline;
 
 import java.io.File;

--- a/src/main/java/com/lassekoskela/maven/timeline/Exporter.java
+++ b/src/main/java/com/lassekoskela/maven/timeline/Exporter.java
@@ -1,0 +1,124 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * 
+ * Copyright (C) 2011-2012  Linagora
+ *
+ * This program is free software: you can redistribute it and/or 
+ * modify it under the terms of the GNU Affero General Public License as 
+ * published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version, provided you comply 
+ * with the Additional Terms applicable for OBM connector by Linagora 
+ * pursuant to Section 7 of the GNU Affero General Public License, 
+ * subsections (b), (c), and (e), pursuant to which you must notably (i) retain 
+ * the “Message sent thanks to OBM, Free Communication by Linagora” 
+ * signature notice appended to any and all outbound messages 
+ * (notably e-mail and meeting requests), (ii) retain all hypertext links between 
+ * OBM and obm.org, as well as between Linagora and linagora.com, and (iii) refrain 
+ * from infringing Linagora intellectual property rights over its trademarks 
+ * and commercial brands. Other Additional Terms apply, 
+ * see <http://www.linagora.com/licenses/> for more details. 
+ *
+ * This program is distributed in the hope that it will be useful, 
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License 
+ * for more details. 
+ *
+ * You should have received a copy of the GNU Affero General Public License 
+ * and its applicable Additional Terms for OBM along with this program. If not, 
+ * see <http://www.gnu.org/licenses/> for the GNU Affero General Public License version 3 
+ * and <http://www.linagora.com/licenses/> for the Additional Terms applicable to 
+ * OBM connectors. 
+ * 
+ * ***** END LICENSE BLOCK ***** */
+package com.lassekoskela.maven.timeline;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.Map;
+
+import org.codehaus.plexus.logging.Logger;
+
+import com.github.mustachejava.DefaultMustacheFactory;
+import com.github.mustachejava.Mustache;
+import com.github.mustachejava.MustacheFactory;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import com.lassekoskela.maven.BuildTimelineExtension;
+import com.lassekoskela.maven.bean.Timeline;
+import com.lassekoskela.maven.timeline.GoalOrganizer.DisplayableGoal;
+
+public class Exporter {
+
+	private static final String TEMPLATE_TIMELINE = "timeline.mustache";
+	private static final String TEMPLATE_BUILDITEM = "buildItem.mustache";
+	private static final String EXPORT_FILE = "timeline.html";
+	
+	private final GoalOrganizer goalOrganizer;
+	private final Mustache timelineMustache;
+	private final Mustache buildItemMustache;
+	
+	public Exporter(Logger logger) throws FileNotFoundException {
+		goalOrganizer = new GoalOrganizer(logger);
+		ClassLoader classLoader = BuildTimelineExtension.class.getClassLoader();
+		MustacheFactory mustacheFactory = new DefaultMustacheFactory();
+		timelineMustache = compileTemplate(classLoader, mustacheFactory, TEMPLATE_TIMELINE);
+		buildItemMustache = compileTemplate(classLoader, mustacheFactory, TEMPLATE_BUILDITEM);
+	}
+
+	private Mustache compileTemplate(ClassLoader ccl, MustacheFactory mf, String template) {
+		return mf.compile(new InputStreamReader(ccl.getResourceAsStream(template)), template);
+	}
+	
+	public File export(Timeline timeline) throws TimelineExportException {
+		try {
+			return serializeTimelineToFile(serializeBuildItems(timeline));
+		} catch (Exception e) {
+			throw new TimelineExportException("Cannot export the timeline as an HTML page", e);
+		}
+	}
+
+	private File serializeTimelineToFile(String serializedBuildItems) throws IOException {
+		File exportFile = getExportFile(EXPORT_FILE);
+		timelineMustache.execute(new FileWriter(exportFile), buildTimelineModel(serializedBuildItems)).flush();
+		return exportFile;
+	}
+
+	private String serializeBuildItems(Timeline timeline) throws IOException {
+		Writer buildItemsWriter = new StringWriter();
+		for (DisplayableGoal displayableGoal : goalOrganizer.organize(timeline)) {
+			buildItemMustache.execute(buildItemsWriter, buildItemModel(displayableGoal));
+		}
+		buildItemsWriter.flush();
+		return buildItemsWriter.toString();
+	}
+
+	@VisibleForTesting File getExportFile(String filePath) {
+		File exportFile = new File(filePath);
+		if (exportFile.exists() && !exportFile.delete()) {
+			throw new IllegalStateException("Cannot delete existing export file");
+		}
+		return exportFile;
+	}
+
+	@VisibleForTesting Map<String, String> buildTimelineModel(String serializedBuildItems) {
+		return ImmutableMap.of("timeline", serializedBuildItems);
+	}
+	
+	@VisibleForTesting Map<String, String> buildItemModel(DisplayableGoal goal) {
+		return ImmutableMap.of(
+				"projectId", goal.getProjectId(),
+				"phaseId", goal.getPhaseId(),
+				"goalId", goal.getGoalId(),
+				"projectDeps", goal.getDependencies(),
+				"cssStyle", cssStyle(goal));
+	}
+
+	@VisibleForTesting String cssStyle(DisplayableGoal goal) {
+		return String.format("height:%dpx;top:%dpx;left:%dpx;",
+				goal.getHeightPosition(), goal.getTopPosition(), goal.getLeftPosition());
+	}
+}

--- a/src/main/java/com/lassekoskela/maven/timeline/GoalOrganizer.java
+++ b/src/main/java/com/lassekoskela/maven/timeline/GoalOrganizer.java
@@ -1,34 +1,3 @@
-/* ***** BEGIN LICENSE BLOCK *****
- * 
- * Copyright (C) 2011-2012  Linagora
- *
- * This program is free software: you can redistribute it and/or 
- * modify it under the terms of the GNU Affero General Public License as 
- * published by the Free Software Foundation, either version 3 of the 
- * License, or (at your option) any later version, provided you comply 
- * with the Additional Terms applicable for OBM connector by Linagora 
- * pursuant to Section 7 of the GNU Affero General Public License, 
- * subsections (b), (c), and (e), pursuant to which you must notably (i) retain 
- * the “Message sent thanks to OBM, Free Communication by Linagora” 
- * signature notice appended to any and all outbound messages 
- * (notably e-mail and meeting requests), (ii) retain all hypertext links between 
- * OBM and obm.org, as well as between Linagora and linagora.com, and (iii) refrain 
- * from infringing Linagora intellectual property rights over its trademarks 
- * and commercial brands. Other Additional Terms apply, 
- * see <http://www.linagora.com/licenses/> for more details. 
- *
- * This program is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
- * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License 
- * for more details. 
- *
- * You should have received a copy of the GNU Affero General Public License 
- * and its applicable Additional Terms for OBM along with this program. If not, 
- * see <http://www.gnu.org/licenses/> for the GNU Affero General Public License version 3 
- * and <http://www.linagora.com/licenses/> for the Additional Terms applicable to 
- * OBM connectors. 
- * 
- * ***** END LICENSE BLOCK ***** */
 package com.lassekoskela.maven.timeline;
 
 import java.util.Comparator;

--- a/src/main/java/com/lassekoskela/maven/timeline/GoalOrganizer.java
+++ b/src/main/java/com/lassekoskela/maven/timeline/GoalOrganizer.java
@@ -1,0 +1,336 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * 
+ * Copyright (C) 2011-2012  Linagora
+ *
+ * This program is free software: you can redistribute it and/or 
+ * modify it under the terms of the GNU Affero General Public License as 
+ * published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version, provided you comply 
+ * with the Additional Terms applicable for OBM connector by Linagora 
+ * pursuant to Section 7 of the GNU Affero General Public License, 
+ * subsections (b), (c), and (e), pursuant to which you must notably (i) retain 
+ * the “Message sent thanks to OBM, Free Communication by Linagora” 
+ * signature notice appended to any and all outbound messages 
+ * (notably e-mail and meeting requests), (ii) retain all hypertext links between 
+ * OBM and obm.org, as well as between Linagora and linagora.com, and (iii) refrain 
+ * from infringing Linagora intellectual property rights over its trademarks 
+ * and commercial brands. Other Additional Terms apply, 
+ * see <http://www.linagora.com/licenses/> for more details. 
+ *
+ * This program is distributed in the hope that it will be useful, 
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License 
+ * for more details. 
+ *
+ * You should have received a copy of the GNU Affero General Public License 
+ * and its applicable Additional Terms for OBM along with this program. If not, 
+ * see <http://www.gnu.org/licenses/> for the GNU Affero General Public License version 3 
+ * and <http://www.linagora.com/licenses/> for the Additional Terms applicable to 
+ * OBM connectors. 
+ * 
+ * ***** END LICENSE BLOCK ***** */
+package com.lassekoskela.maven.timeline;
+
+import java.util.Comparator;
+import java.util.LinkedList;
+
+import org.codehaus.plexus.logging.Logger;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.ImmutableSortedSet.Builder;
+import com.google.common.collect.Lists;
+import com.google.common.collect.TreeMultiset;
+import com.google.common.primitives.Ints;
+import com.google.common.primitives.Longs;
+import com.lassekoskela.maven.bean.Goal;
+import com.lassekoskela.maven.bean.Phase;
+import com.lassekoskela.maven.bean.Project;
+import com.lassekoskela.maven.bean.Timeline;
+
+
+public class GoalOrganizer {
+	
+	public static final int COLUMN_WIDTH_PIXEL = 60;
+	public static final int HEIGHT_SECOND_SCALING_PIXEL = 4;
+	public static final double HEIGHT_MSECOND_SCALING_PIXEL = HEIGHT_SECOND_SCALING_PIXEL / 1000d;
+	
+	private final Logger logger;
+	
+	public GoalOrganizer(Logger logger) {
+		this.logger = logger;
+	}
+	
+	public Iterable<DisplayableGoal> organize(Timeline timeline) {
+		ImmutableList.Builder<DisplayableGoal> goals = ImmutableList.builder();
+		Columns columnOfGoals = new Columns();
+		
+		Iterable<SortedGoal> sortedGoalsByStartTime = sortedGoalsByStartTime(timeline);
+		logGoals(sortedGoalsByStartTime);
+		for (SortedGoal sortedGoal : sortedGoalsByStartTime) {
+			goals.add(buildDisplayableGoal(columnOfGoals, sortedGoal));
+		}
+		return goals.build();
+	}
+
+	private void logGoals(Iterable<SortedGoal> sortedGoalsByStartTime) {
+		String formatColumns = "%-70s%15s%15s%15s";
+		logger.info(String.format(formatColumns, "Goal", "start time", "duration", "end time"));
+		for (SortedGoal sortedGoal : sortedGoalsByStartTime) {
+			Goal goal = sortedGoal.goal;
+			logger.info(String.format(formatColumns, sortedGoal.project.getItemId() + " " + sortedGoal.phase.getItemId() + " " + goal.getItemId(),
+					goal.getStartTimeInMs(), goal.getDuration().toString(), goal.getCompletedTimeInMs()));
+		}
+	}
+
+	@VisibleForTesting Iterable<SortedGoal> sortedGoalsByStartTime(Timeline timeline) {
+		Builder<SortedGoal> sortingGoalSet = ImmutableSortedSet.orderedBy(newGoalStartTimeComparator());
+		for (Project project : timeline.getProjects()) {
+			for (Phase phase : project.getPhases()) {
+				for (Goal goal : phase.getGoals()) {
+					sortingGoalSet.add(new SortedGoal(project, phase, goal));
+				}
+			}
+		}
+		return sortingGoalSet.build();
+	}
+
+	@VisibleForTesting Comparator<SortedGoal> newGoalStartTimeComparator() {
+		return new Comparator<SortedGoal>() {
+			@Override
+			public int compare(SortedGoal o1, SortedGoal o2) {
+				if (o1.goal.getStartTimeInMs() != o2.goal.getStartTimeInMs()) {
+					return Longs.compare(o1.goal.getStartTimeInMs(), o2.goal.getStartTimeInMs());
+				}
+				return Longs.compare(o1.goal.getCompletedTimeInMs(), o2.goal.getCompletedTimeInMs());
+			}
+		};
+	}
+
+	@VisibleForTesting DisplayableGoal buildDisplayableGoal(Columns columnOfGoals, SortedGoal sortedGoal) {
+		return new DisplayableGoal(
+				sortedGoal.project.getItemId(),
+				sortedGoal.phase.getItemId(),
+				sortedGoal.goal.getItemId(),
+				sortedGoal.goal.serializeDependencies(),
+				columnToLeftPosition(appendGoalInRightColumn(columnOfGoals, sortedGoal.goal)),
+				goalTopPosition(sortedGoal.goal),
+				goalHeightValue(sortedGoal.goal));
+	}
+	
+	private long goalHeightValue(Goal goal) {
+		return verticalValue(goal.getDuration().inMillis());
+	}
+
+	private long goalTopPosition(Goal goal) {
+		return verticalValue(goal.getStartTimeInMs());
+	}
+	
+	@VisibleForTesting long verticalValue(long millis) {
+		Preconditions.checkArgument(millis >= 0);
+		return Math.round(Math.ceil(millis * HEIGHT_MSECOND_SCALING_PIXEL));
+	}
+
+	@VisibleForTesting long columnToLeftPosition(int goalColumn) {
+		Preconditions.checkArgument(goalColumn >= 0);
+		return goalColumn * COLUMN_WIDTH_PIXEL;
+	}
+
+	private int appendGoalInRightColumn(Columns columnOfGoals, Goal goal) {
+		return columnOfGoals.addGoal(goal);
+	}
+	
+	@VisibleForTesting static class Column implements Comparable<Column> {
+		
+		private final int index;
+		private final LinkedList<Goal> goals;
+		
+		@VisibleForTesting Column(int index) {
+			this.index = index;
+			goals = Lists.newLinkedList();
+		}
+		
+		public void addGoal(Goal goal) {
+			goals.add(goal);
+		}
+		
+		public long lastGoalEnd() {
+			if (goals.isEmpty()) {
+				return 0;
+			}
+			return goals.getLast().getCompletedTimeInMs();
+		}
+
+		@Override
+		public int compareTo(Column o) {
+			int comparingGoalEnd = Longs.compare(lastGoalEnd(), o.lastGoalEnd());
+			if (comparingGoalEnd == 0) {
+				return Ints.compare(this.index, o.index);
+			}
+			return comparingGoalEnd;
+		}
+
+		public boolean goalFits(Goal goal) {
+			return goal.getStartTimeInMs() >= lastGoalEnd();
+		}
+	}
+	
+	@VisibleForTesting static class Columns {
+		
+		private TreeMultiset<Column> columns;
+		
+		@VisibleForTesting Columns() {
+			columns = TreeMultiset.create();
+			columns.add(newColumn());
+		}
+
+		private Column newColumn() {
+			return new Column(columns.size());
+		}
+		
+		public int addGoal(Goal goal) {
+			Column column = selectColumn(goal);
+			addGoalToColumn(goal, column);
+			return column.index;
+		}
+
+		private Column selectColumn(Goal goal) {
+			Column earliestEndingColumn = columns.firstEntry().getElement();
+			if (earliestEndingColumn.goalFits(goal)) {
+				return columns.pollFirstEntry().getElement();
+			}
+			return newColumn();
+		}
+		
+		private void addGoalToColumn(Goal goal, Column column) {
+			column.addGoal(goal);
+			columns.add(column);
+		}
+	}
+
+	@VisibleForTesting static class SortedGoal {
+		
+		private final Project project;
+		private final Phase phase;
+		private final Goal goal;
+
+		@VisibleForTesting SortedGoal(Project project, Phase phase, Goal goal) {
+			this.project = project;
+			this.phase = phase;
+			this.goal = goal;
+		}
+
+		@Override
+		public int hashCode(){
+			return Objects.hashCode(project, phase, goal);
+		}
+		
+		@Override
+		public boolean equals(Object object){
+			if (object instanceof SortedGoal) {
+				SortedGoal that = (SortedGoal) object;
+				return Objects.equal(this.project, that.project)
+					&& Objects.equal(this.phase, that.phase)
+					&& Objects.equal(this.goal, that.goal);
+			}
+			return false;
+		}
+
+		@Override
+		public String toString() {
+			return Objects.toStringHelper(this)
+				.add("project", project)
+				.add("phase", phase)
+				.add("goal", goal)
+				.toString();
+		}
+	}
+
+	public static class DisplayableGoal {
+		
+		private final String projectId;
+		private final String phaseId;
+		private final String goalId;
+		private final String dependencies;
+		private final long leftPosition;
+		private final long topPosition;
+		private final long heightPosition;
+
+		@VisibleForTesting DisplayableGoal(String projectId, String phaseId, String goalId, String dependencies,
+				long leftPosition, long topPosition, long heightPosition) {
+			
+			this.projectId = projectId;
+			this.phaseId = phaseId;
+			this.goalId = goalId;
+			this.dependencies = dependencies;
+			this.leftPosition = leftPosition;
+			this.topPosition = topPosition;
+			this.heightPosition = heightPosition;
+		}
+
+		public String getProjectId() {
+			return projectId;
+		}
+
+		public String getPhaseId() {
+			return phaseId;
+		}
+
+		public String getGoalId() {
+			return goalId;
+		}
+
+		public String getDependencies() {
+			return dependencies;
+		}
+
+		public long getLeftPosition() {
+			return leftPosition;
+		}
+
+		public long getTopPosition() {
+			return topPosition;
+		}
+
+		public long getHeightPosition() {
+			return heightPosition;
+		}
+
+		@Override
+		public int hashCode(){
+			return Objects.hashCode(projectId, phaseId, goalId, dependencies, leftPosition, topPosition, heightPosition);
+		}
+		
+		@Override
+		public boolean equals(Object object){
+			if (object instanceof DisplayableGoal) {
+				DisplayableGoal that = (DisplayableGoal) object;
+				return Objects.equal(this.projectId, that.projectId)
+					&& Objects.equal(this.phaseId, that.phaseId)
+					&& Objects.equal(this.goalId, that.goalId)
+					&& Objects.equal(this.dependencies, that.dependencies)
+					&& Objects.equal(this.leftPosition, that.leftPosition)
+					&& Objects.equal(this.topPosition, that.topPosition)
+					&& Objects.equal(this.heightPosition, that.heightPosition);
+			}
+			return false;
+		}
+
+		@Override
+		public String toString() {
+			return Objects.toStringHelper(this)
+				.add("projectId", projectId)
+				.add("phaseId", phaseId)
+				.add("goalId", goalId)
+				.add("dependencies", dependencies)
+				.add("leftPosition", leftPosition)
+				.add("topPosition", topPosition)
+				.add("heightPosition", heightPosition)
+				.toString();
+		}
+	}
+	
+}

--- a/src/main/java/com/lassekoskela/maven/timeline/GoalOrganizer.java
+++ b/src/main/java/com/lassekoskela/maven/timeline/GoalOrganizer.java
@@ -46,12 +46,14 @@ public class GoalOrganizer {
 	}
 
 	private void logGoals(Iterable<SortedGoal> sortedGoalsByStartTime) {
-		String formatColumns = "%-70s%15s%15s%15s";
-		logger.info(String.format(formatColumns, "Goal", "start time", "duration", "end time"));
-		for (SortedGoal sortedGoal : sortedGoalsByStartTime) {
-			Goal goal = sortedGoal.goal;
-			logger.info(String.format(formatColumns, sortedGoal.project.getItemId() + " " + sortedGoal.phase.getItemId() + " " + goal.getItemId(),
-					goal.getStartTimeInMs(), goal.getDuration().toString(), goal.getCompletedTimeInMs()));
+		if (logger.isDebugEnabled()) {
+			String formatColumns = "%-70s%15s%15s%15s";
+			logger.debug(String.format(formatColumns, "Goal", "start time", "duration", "end time"));
+			for (SortedGoal sortedGoal : sortedGoalsByStartTime) {
+				Goal goal = sortedGoal.goal;
+				logger.debug(String.format(formatColumns, sortedGoal.project.getItemId() + " " + sortedGoal.phase.getItemId() + " " + goal.getItemId(),
+						goal.getStartTimeInMs(), goal.getDuration().toString(), goal.getCompletedTimeInMs()));
+			}
 		}
 	}
 

--- a/src/main/java/com/lassekoskela/maven/timeline/TimelineExportException.java
+++ b/src/main/java/com/lassekoskela/maven/timeline/TimelineExportException.java
@@ -1,0 +1,54 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * 
+ * Copyright (C) 2011-2012  Linagora
+ *
+ * This program is free software: you can redistribute it and/or 
+ * modify it under the terms of the GNU Affero General Public License as 
+ * published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version, provided you comply 
+ * with the Additional Terms applicable for OBM connector by Linagora 
+ * pursuant to Section 7 of the GNU Affero General Public License, 
+ * subsections (b), (c), and (e), pursuant to which you must notably (i) retain 
+ * the “Message sent thanks to OBM, Free Communication by Linagora” 
+ * signature notice appended to any and all outbound messages 
+ * (notably e-mail and meeting requests), (ii) retain all hypertext links between 
+ * OBM and obm.org, as well as between Linagora and linagora.com, and (iii) refrain 
+ * from infringing Linagora intellectual property rights over its trademarks 
+ * and commercial brands. Other Additional Terms apply, 
+ * see <http://www.linagora.com/licenses/> for more details. 
+ *
+ * This program is distributed in the hope that it will be useful, 
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License 
+ * for more details. 
+ *
+ * You should have received a copy of the GNU Affero General Public License 
+ * and its applicable Additional Terms for OBM along with this program. If not, 
+ * see <http://www.gnu.org/licenses/> for the GNU Affero General Public License version 3 
+ * and <http://www.linagora.com/licenses/> for the Additional Terms applicable to 
+ * OBM connectors. 
+ * 
+ * ***** END LICENSE BLOCK ***** */
+package com.lassekoskela.maven.timeline;
+
+public class TimelineExportException extends RuntimeException {
+
+	private static final long serialVersionUID = -3189917456725342101L;
+
+	public TimelineExportException() {
+		super();
+	}
+
+	public TimelineExportException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public TimelineExportException(String message) {
+		super(message);
+	}
+
+	public TimelineExportException(Throwable cause) {
+		super(cause);
+	}
+
+}

--- a/src/main/java/com/lassekoskela/maven/timeline/TimelineExportException.java
+++ b/src/main/java/com/lassekoskela/maven/timeline/TimelineExportException.java
@@ -1,34 +1,3 @@
-/* ***** BEGIN LICENSE BLOCK *****
- * 
- * Copyright (C) 2011-2012  Linagora
- *
- * This program is free software: you can redistribute it and/or 
- * modify it under the terms of the GNU Affero General Public License as 
- * published by the Free Software Foundation, either version 3 of the 
- * License, or (at your option) any later version, provided you comply 
- * with the Additional Terms applicable for OBM connector by Linagora 
- * pursuant to Section 7 of the GNU Affero General Public License, 
- * subsections (b), (c), and (e), pursuant to which you must notably (i) retain 
- * the “Message sent thanks to OBM, Free Communication by Linagora” 
- * signature notice appended to any and all outbound messages 
- * (notably e-mail and meeting requests), (ii) retain all hypertext links between 
- * OBM and obm.org, as well as between Linagora and linagora.com, and (iii) refrain 
- * from infringing Linagora intellectual property rights over its trademarks 
- * and commercial brands. Other Additional Terms apply, 
- * see <http://www.linagora.com/licenses/> for more details. 
- *
- * This program is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
- * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License 
- * for more details. 
- *
- * You should have received a copy of the GNU Affero General Public License 
- * and its applicable Additional Terms for OBM along with this program. If not, 
- * see <http://www.gnu.org/licenses/> for the GNU Affero General Public License version 3 
- * and <http://www.linagora.com/licenses/> for the Additional Terms applicable to 
- * OBM connectors. 
- * 
- * ***** END LICENSE BLOCK ***** */
 package com.lassekoskela.maven.timeline;
 
 public class TimelineExportException extends RuntimeException {

--- a/src/main/java/com/lassekoskela/time/DateProvider.java
+++ b/src/main/java/com/lassekoskela/time/DateProvider.java
@@ -1,0 +1,39 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * 
+ * Copyright (C) 2011-2012  Linagora
+ *
+ * This program is free software: you can redistribute it and/or 
+ * modify it under the terms of the GNU Affero General Public License as 
+ * published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version, provided you comply 
+ * with the Additional Terms applicable for OBM connector by Linagora 
+ * pursuant to Section 7 of the GNU Affero General Public License, 
+ * subsections (b), (c), and (e), pursuant to which you must notably (i) retain 
+ * the “Message sent thanks to OBM, Free Communication by Linagora” 
+ * signature notice appended to any and all outbound messages 
+ * (notably e-mail and meeting requests), (ii) retain all hypertext links between 
+ * OBM and obm.org, as well as between Linagora and linagora.com, and (iii) refrain 
+ * from infringing Linagora intellectual property rights over its trademarks 
+ * and commercial brands. Other Additional Terms apply, 
+ * see <http://www.linagora.com/licenses/> for more details. 
+ *
+ * This program is distributed in the hope that it will be useful, 
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License 
+ * for more details. 
+ *
+ * You should have received a copy of the GNU Affero General Public License 
+ * and its applicable Additional Terms for OBM along with this program. If not, 
+ * see <http://www.gnu.org/licenses/> for the GNU Affero General Public License version 3 
+ * and <http://www.linagora.com/licenses/> for the Additional Terms applicable to 
+ * OBM connectors. 
+ * 
+ * ***** END LICENSE BLOCK ***** */
+package com.lassekoskela.time;
+
+import java.util.Date;
+
+public interface DateProvider {
+
+	Date now();
+}

--- a/src/main/java/com/lassekoskela/time/DateProvider.java
+++ b/src/main/java/com/lassekoskela/time/DateProvider.java
@@ -1,34 +1,3 @@
-/* ***** BEGIN LICENSE BLOCK *****
- * 
- * Copyright (C) 2011-2012  Linagora
- *
- * This program is free software: you can redistribute it and/or 
- * modify it under the terms of the GNU Affero General Public License as 
- * published by the Free Software Foundation, either version 3 of the 
- * License, or (at your option) any later version, provided you comply 
- * with the Additional Terms applicable for OBM connector by Linagora 
- * pursuant to Section 7 of the GNU Affero General Public License, 
- * subsections (b), (c), and (e), pursuant to which you must notably (i) retain 
- * the “Message sent thanks to OBM, Free Communication by Linagora” 
- * signature notice appended to any and all outbound messages 
- * (notably e-mail and meeting requests), (ii) retain all hypertext links between 
- * OBM and obm.org, as well as between Linagora and linagora.com, and (iii) refrain 
- * from infringing Linagora intellectual property rights over its trademarks 
- * and commercial brands. Other Additional Terms apply, 
- * see <http://www.linagora.com/licenses/> for more details. 
- *
- * This program is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
- * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License 
- * for more details. 
- *
- * You should have received a copy of the GNU Affero General Public License 
- * and its applicable Additional Terms for OBM along with this program. If not, 
- * see <http://www.gnu.org/licenses/> for the GNU Affero General Public License version 3 
- * and <http://www.linagora.com/licenses/> for the Additional Terms applicable to 
- * OBM connectors. 
- * 
- * ***** END LICENSE BLOCK ***** */
 package com.lassekoskela.time;
 
 import java.util.Date;

--- a/src/main/java/com/lassekoskela/time/DateProviderImpl.java
+++ b/src/main/java/com/lassekoskela/time/DateProviderImpl.java
@@ -1,0 +1,43 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * 
+ * Copyright (C) 2011-2012  Linagora
+ *
+ * This program is free software: you can redistribute it and/or 
+ * modify it under the terms of the GNU Affero General Public License as 
+ * published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version, provided you comply 
+ * with the Additional Terms applicable for OBM connector by Linagora 
+ * pursuant to Section 7 of the GNU Affero General Public License, 
+ * subsections (b), (c), and (e), pursuant to which you must notably (i) retain 
+ * the “Message sent thanks to OBM, Free Communication by Linagora” 
+ * signature notice appended to any and all outbound messages 
+ * (notably e-mail and meeting requests), (ii) retain all hypertext links between 
+ * OBM and obm.org, as well as between Linagora and linagora.com, and (iii) refrain 
+ * from infringing Linagora intellectual property rights over its trademarks 
+ * and commercial brands. Other Additional Terms apply, 
+ * see <http://www.linagora.com/licenses/> for more details. 
+ *
+ * This program is distributed in the hope that it will be useful, 
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License 
+ * for more details. 
+ *
+ * You should have received a copy of the GNU Affero General Public License 
+ * and its applicable Additional Terms for OBM along with this program. If not, 
+ * see <http://www.gnu.org/licenses/> for the GNU Affero General Public License version 3 
+ * and <http://www.linagora.com/licenses/> for the Additional Terms applicable to 
+ * OBM connectors. 
+ * 
+ * ***** END LICENSE BLOCK ***** */
+package com.lassekoskela.time;
+
+import java.util.Date;
+
+public class DateProviderImpl implements DateProvider {
+
+	@Override
+	public Date now() {
+		return new Date(Clock.now());
+	}
+
+}

--- a/src/main/java/com/lassekoskela/time/DateProviderImpl.java
+++ b/src/main/java/com/lassekoskela/time/DateProviderImpl.java
@@ -1,34 +1,3 @@
-/* ***** BEGIN LICENSE BLOCK *****
- * 
- * Copyright (C) 2011-2012  Linagora
- *
- * This program is free software: you can redistribute it and/or 
- * modify it under the terms of the GNU Affero General Public License as 
- * published by the Free Software Foundation, either version 3 of the 
- * License, or (at your option) any later version, provided you comply 
- * with the Additional Terms applicable for OBM connector by Linagora 
- * pursuant to Section 7 of the GNU Affero General Public License, 
- * subsections (b), (c), and (e), pursuant to which you must notably (i) retain 
- * the “Message sent thanks to OBM, Free Communication by Linagora” 
- * signature notice appended to any and all outbound messages 
- * (notably e-mail and meeting requests), (ii) retain all hypertext links between 
- * OBM and obm.org, as well as between Linagora and linagora.com, and (iii) refrain 
- * from infringing Linagora intellectual property rights over its trademarks 
- * and commercial brands. Other Additional Terms apply, 
- * see <http://www.linagora.com/licenses/> for more details. 
- *
- * This program is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
- * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License 
- * for more details. 
- *
- * You should have received a copy of the GNU Affero General Public License 
- * and its applicable Additional Terms for OBM along with this program. If not, 
- * see <http://www.gnu.org/licenses/> for the GNU Affero General Public License version 3 
- * and <http://www.linagora.com/licenses/> for the Additional Terms applicable to 
- * OBM connectors. 
- * 
- * ***** END LICENSE BLOCK ***** */
 package com.lassekoskela.time;
 
 import java.util.Date;

--- a/src/main/java/com/lassekoskela/time/Duration.java
+++ b/src/main/java/com/lassekoskela/time/Duration.java
@@ -1,5 +1,9 @@
 package com.lassekoskela.time;
 
+import com.google.common.base.Objects;
+import com.google.common.base.Objects.ToStringHelper;
+import com.lassekoskela.maven.bean.Phase;
+
 public class Duration {
 	private static final int MILLIS_IN_HOUR = 60 * 60 * 1000;
 	private static final int MILLIS_IN_MINUTE = 60 * 1000;
@@ -16,6 +20,11 @@ public class Duration {
 		calculateTimeUnitsFrom(milliseconds);
 	}
 
+	@Override
+	public int hashCode(){
+		return Objects.hashCode(inMilliseconds);
+	}
+	
 	@Override
 	public boolean equals(Object obj) {
 		if (!obj.getClass().equals(getClass())) {

--- a/src/main/java/com/lassekoskela/time/Duration.java
+++ b/src/main/java/com/lassekoskela/time/Duration.java
@@ -1,8 +1,6 @@
 package com.lassekoskela.time;
 
 import com.google.common.base.Objects;
-import com.google.common.base.Objects.ToStringHelper;
-import com.lassekoskela.maven.bean.Phase;
 
 public class Duration {
 	private static final int MILLIS_IN_HOUR = 60 * 60 * 1000;

--- a/src/main/resources/buildItem.mustache
+++ b/src/main/resources/buildItem.mustache
@@ -1,0 +1,8 @@
+<div id="{{projectId}}-{{phaseId}}-{{goalId}}" 
+		class="build-item build-item-{{phaseId}}"
+		style="{{cssStyle}}"
+		title="{{projectId}} ({{phaseId}}:{{goalId}})"
+		data-deps="{{projectDeps}}"
+		onclick="buildItemClicked(this)">
+			{{projectId}}</div>
+

--- a/src/main/resources/timeline.mustache
+++ b/src/main/resources/timeline.mustache
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<META http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+		<title>Your Maven build</title>
+		<style type="text/css">
+			body {
+				border-top: red 2px solid;
+				border-left: red 2px solid;
+				padding: 10px;
+				position: relative;
+				min-height: 600px;
+			}
+			.build-item {
+				position: absolute;
+				width: 50px;
+				font-size: 20px;
+				letter-spacing: 20px;
+				line-height: 100%;
+				text-align: center;
+				word-wrap: break-word;
+				overflow: hidden;
+				-moz-border-radius: 5px;
+				border-radius: 5px;
+				opacity:0.85;
+				background-color: lightGray;
+			}
+			.build-item:hover {
+				box-shadow: 0px 0px 0px 2px black;
+				opacity:1;
+			}
+			.build-item-selected {
+				box-shadow: 0px 0px 0px 1px black;
+				opacity:1;
+			}
+			.build-item-highlight {
+				box-shadow: 0px 0px 0px 1px red;
+				opacity:1;
+			}
+			.build-item-pre-clean {
+				background-color: #CCA300;
+			}
+			.build-item-clean {
+				background-color: #FFCC00;
+			}
+			.build-item-post-clean {
+				background-color: #FFD633;
+			}
+			.build-item-validate {
+				background-color: #3366CC;
+			}
+			.build-item-initialize {
+				background-color: #5C85D6;
+			}
+			.build-item-generate-sources {
+				background-color: #0099CC;
+			}
+			.build-item-process-sources {
+				background-color: #33ADD6
+			}
+			.build-item-generate-resources {
+				background-color: #33CCCC
+			}
+			.build-item-process-resources {
+				background-color: #5CD6D6
+			}
+			.build-item-compile {
+				background-color: #00FFCC
+			}
+			.build-item-process-classes {
+				background-color: #33FFD6
+			}
+			.build-item-generate-test-sources {
+				background-color: #00FF99
+			}
+			.build-item-process-test-sources {
+				background-color: #33FFAD
+			}
+			.build-item-generate-test-resources {
+				background-color: #00B200
+			}
+			.build-item-process-test-resources {
+				background-color: #00E600
+			}
+			.build-item-test-compile {
+				background-color: #33CC33
+			}
+			.build-item-process-test-classes {
+				background-color: #5CD65C
+			}
+			.build-item-test {
+				background-color: #19A319
+			}
+			.build-item-prepare-package {
+				background-color: #4DB84D
+			}
+			.build-item-package {
+				background-color: #47A375
+			}
+			.build-item-pre-integration-test {
+				background-color: #70B894
+			}
+			.build-item-integration-test {
+				background-color: #99CCB2
+			}
+			.build-item-post-integration-test {
+				background-color: #C2E0D1
+			}
+			.build-item-verify {
+				background-color: #AD33AD
+			}
+			.build-item-install {
+				background-color: #C266C2
+			}
+			.build-item-deploy {
+				background-color: #D699D6
+			}
+		</style>
+	</head>
+	<body>
+
+		{{{timeline}}}
+
+		<script type="text/javascript">
+
+			var selectedBuildItem = null;
+			var highlightedBuildItems = [];
+
+			function buildItemClicked(buildItem) {
+				removeHighlights();
+				changeSelectedBuildItem(buildItem);
+				addHighlights(buildItem);
+			}
+
+			function addHighlights(buildItem) {
+				buildItem.dataset.deps.split(" ").forEach(function(dependencyId) {
+					if (dependencyId == "") {
+						return;
+					}
+					var dependencyElement = document.getElementById(dependencyId);
+					highlightedBuildItems.push(dependencyId);
+					dependencyElement.classList.add("build-item-highlight");
+				});
+			}
+
+			function changeSelectedBuildItem(newSelectedBuildItem) {
+				if (selectedBuildItem != null) {
+					selectedBuildItem.classList.remove("build-item-selected");
+				}
+				newSelectedBuildItem.classList.add("build-item-selected");
+				selectedBuildItem = newSelectedBuildItem;
+			}
+
+			function removeHighlights() {
+				highlightedBuildItems.forEach(function(dependencyId) {
+					document.getElementById(dependencyId).classList.remove("build-item-highlight");
+				});
+				highlightedBuildItems = [];
+			}
+		</script>
+	</body>
+</html>

--- a/src/main/resources/timeline.mustache
+++ b/src/main/resources/timeline.mustache
@@ -6,7 +6,6 @@
 		<style type="text/css">
 			body {
 				border-top: red 2px solid;
-				border-left: red 2px solid;
 				padding: 10px;
 				position: relative;
 				min-height: 600px;

--- a/src/test/java/com/lassekoskela/maven/bean/GoalTest.java
+++ b/src/test/java/com/lassekoskela/maven/bean/GoalTest.java
@@ -1,0 +1,43 @@
+package com.lassekoskela.maven.bean;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.google.common.collect.Sets;
+import com.lassekoskela.time.Duration;
+
+
+public class GoalTest {
+
+	@Test
+	public void testGoalNoDependencies() {
+		Goal goal = new Goal("goal", new Duration(2000), 100, Sets.<String> newHashSet());
+		
+		assertTrue(goal.getDependencies().isEmpty());
+		assertTrue(goal.serializeDependencies().isEmpty());
+	}
+	
+	@Test
+	public void testGoalThreeDependencies() {
+		Goal goal = new Goal("goal", new Duration(2000), 100, Sets.newHashSet("dep1", "dep2", "dep3"));
+		
+		assertEquals(goal.getDependencies(), Sets.newHashSet("dep1", "dep2", "dep3"));
+		assertEquals(goal.serializeDependencies(), "dep1 dep2 dep3");
+	}
+	
+	@Test
+	public void testGoalGetCompletedTimeWhenZero() {
+		Goal goal = new Goal("goal", new Duration(0), 0, Sets.<String>newHashSet());
+		
+		assertEquals(goal.getCompletedTimeInMs(), 0);
+	}
+	
+	@Test
+	public void testGoalGetCompletedTime() {
+		Goal goal = new Goal("goal", new Duration(1200), 100, Sets.<String>newHashSet());
+		
+		assertEquals(goal.getCompletedTimeInMs(), 1300);
+	}
+}

--- a/src/test/java/com/lassekoskela/maven/bean/PhaseTest.java
+++ b/src/test/java/com/lassekoskela/maven/bean/PhaseTest.java
@@ -15,12 +15,12 @@ public class PhaseTest {
 	
 	@Before
 	public void setup() {
-		phase = new Phase("prj", new Duration(2400), Sets.<Goal> newHashSet());
+		phase = new Phase("prj", Sets.<Goal> newHashSet());
 	}
 	
 	@Test
 	public void testAddGoal() {
-		phase.addGoal(new Goal("goal", new Duration(1200), 1000));
+		phase.addGoal(new Goal("goal", new Duration(2000), 1000));
 		
 		assertEquals(phase.getGoals().size(), 1);
 	}

--- a/src/test/java/com/lassekoskela/maven/bean/PhaseTest.java
+++ b/src/test/java/com/lassekoskela/maven/bean/PhaseTest.java
@@ -20,7 +20,7 @@ public class PhaseTest {
 	
 	@Test
 	public void testAddGoal() {
-		phase.addGoal(new Goal("goal", new Duration(1200)));
+		phase.addGoal(new Goal("goal", new Duration(1200), 1000));
 		
 		assertEquals(phase.getGoals().size(), 1);
 	}

--- a/src/test/java/com/lassekoskela/maven/bean/PhaseTest.java
+++ b/src/test/java/com/lassekoskela/maven/bean/PhaseTest.java
@@ -20,7 +20,7 @@ public class PhaseTest {
 	
 	@Test
 	public void testAddGoal() {
-		phase.addGoal(new Goal("goal", new Duration(2000), 1000));
+		phase.addGoal(new Goal("goal", new Duration(2000), 1000, Sets.<String> newHashSet()));
 		
 		assertEquals(phase.getGoals().size(), 1);
 	}

--- a/src/test/java/com/lassekoskela/maven/bean/ProjectTest.java
+++ b/src/test/java/com/lassekoskela/maven/bean/ProjectTest.java
@@ -6,7 +6,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.collect.Sets;
-import com.lassekoskela.time.Duration;
 
 
 public class ProjectTest {
@@ -15,12 +14,12 @@ public class ProjectTest {
 	
 	@Before
 	public void setup() {
-		project = new Project("prj", new Duration(2400), Sets.<Phase> newHashSet());
+		project = new Project("prj", Sets.<Phase> newHashSet());
 	}
 	
 	@Test
 	public void testAddPhase() {
-		project.addPhase(new Phase("phase", new Duration(1200), Sets.<Goal> newHashSet()));
+		project.addPhase(new Phase("phase", Sets.<Goal> newHashSet()));
 		
 		assertEquals(project.getPhases().size(), 1);
 	}

--- a/src/test/java/com/lassekoskela/maven/bean/TimelineTest.java
+++ b/src/test/java/com/lassekoskela/maven/bean/TimelineTest.java
@@ -2,26 +2,22 @@ package com.lassekoskela.maven.bean;
 
 import static org.junit.Assert.assertEquals;
 
-import org.junit.Before;
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.lassekoskela.time.Duration;
 
 
 public class TimelineTest {
 
-	private Timeline timeline;
-	
-	@Before
-	public void setup() {
-		timeline = new Timeline(Sets.<Project> newHashSet());
-	}
 	
 	@Test
 	public void testAddProject() {
-		timeline.addProject(new Project("prj", new Duration(2400), Sets.<Phase> newHashSet()));
+		Timeline timeline = new Timeline(ImmutableSet.of(
+				new Project("prj", new Duration(2400), Sets.<Phase> newHashSet())));
 		
-		assertEquals(timeline.getProjects().size(), 1);
+		assertEquals(Iterables.size(timeline.getProjects()), 1);
 	}
 }

--- a/src/test/java/com/lassekoskela/maven/bean/TimelineTest.java
+++ b/src/test/java/com/lassekoskela/maven/bean/TimelineTest.java
@@ -7,7 +7,6 @@ import org.junit.Test;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
-import com.lassekoskela.time.Duration;
 
 
 public class TimelineTest {
@@ -16,7 +15,7 @@ public class TimelineTest {
 	@Test
 	public void testAddProject() {
 		Timeline timeline = new Timeline(ImmutableSet.of(
-				new Project("prj", new Duration(2400), Sets.<Phase> newHashSet())));
+				new Project("prj", Sets.<Phase> newHashSet())));
 		
 		assertEquals(Iterables.size(timeline.getProjects()), 1);
 	}

--- a/src/test/java/com/lassekoskela/maven/buildevents/AbstractBuildEventLogTest.java
+++ b/src/test/java/com/lassekoskela/maven/buildevents/AbstractBuildEventLogTest.java
@@ -53,12 +53,12 @@ public abstract class AbstractBuildEventLogTest {
 		Clock.reset();
 	}
 
-	protected Matcher<Iterable<BuildStep>> hasBuildStep(String phase,
+	protected Matcher<Iterable<? super BuildStep>> hasBuildStep(String phase,
 			String goal) {
 		return hasBuildStep(simulator.project, phase, goal);
 	}
 
-	protected Matcher<Iterable<BuildStep>> hasBuildStep(String project,
+	protected Matcher<Iterable<? super BuildStep>> hasBuildStep(String project,
 			String phase, String goal) {
 		BuildStep step = new BuildStep(project, phase, simulator.groupId,
 				simulator.artifactId, goal);

--- a/src/test/java/com/lassekoskela/maven/timeline/BuildTimelineListenerTest.java
+++ b/src/test/java/com/lassekoskela/maven/timeline/BuildTimelineListenerTest.java
@@ -1,34 +1,3 @@
-/* ***** BEGIN LICENSE BLOCK *****
- * 
- * Copyright (C) 2011-2012  Linagora
- *
- * This program is free software: you can redistribute it and/or 
- * modify it under the terms of the GNU Affero General Public License as 
- * published by the Free Software Foundation, either version 3 of the 
- * License, or (at your option) any later version, provided you comply 
- * with the Additional Terms applicable for OBM connector by Linagora 
- * pursuant to Section 7 of the GNU Affero General Public License, 
- * subsections (b), (c), and (e), pursuant to which you must notably (i) retain 
- * the “Message sent thanks to OBM, Free Communication by Linagora” 
- * signature notice appended to any and all outbound messages 
- * (notably e-mail and meeting requests), (ii) retain all hypertext links between 
- * OBM and obm.org, as well as between Linagora and linagora.com, and (iii) refrain 
- * from infringing Linagora intellectual property rights over its trademarks 
- * and commercial brands. Other Additional Terms apply, 
- * see <http://www.linagora.com/licenses/> for more details. 
- *
- * This program is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
- * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License 
- * for more details. 
- *
- * You should have received a copy of the GNU Affero General Public License 
- * and its applicable Additional Terms for OBM along with this program. If not, 
- * see <http://www.gnu.org/licenses/> for the GNU Affero General Public License version 3 
- * and <http://www.linagora.com/licenses/> for the Additional Terms applicable to 
- * OBM connectors. 
- * 
- * ***** END LICENSE BLOCK ***** */
 package com.lassekoskela.maven.timeline;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/com/lassekoskela/maven/timeline/BuildTimelineListenerTest.java
+++ b/src/test/java/com/lassekoskela/maven/timeline/BuildTimelineListenerTest.java
@@ -1,0 +1,235 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * 
+ * Copyright (C) 2011-2012  Linagora
+ *
+ * This program is free software: you can redistribute it and/or 
+ * modify it under the terms of the GNU Affero General Public License as 
+ * published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version, provided you comply 
+ * with the Additional Terms applicable for OBM connector by Linagora 
+ * pursuant to Section 7 of the GNU Affero General Public License, 
+ * subsections (b), (c), and (e), pursuant to which you must notably (i) retain 
+ * the “Message sent thanks to OBM, Free Communication by Linagora” 
+ * signature notice appended to any and all outbound messages 
+ * (notably e-mail and meeting requests), (ii) retain all hypertext links between 
+ * OBM and obm.org, as well as between Linagora and linagora.com, and (iii) refrain 
+ * from infringing Linagora intellectual property rights over its trademarks 
+ * and commercial brands. Other Additional Terms apply, 
+ * see <http://www.linagora.com/licenses/> for more details. 
+ *
+ * This program is distributed in the hope that it will be useful, 
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License 
+ * for more details. 
+ *
+ * You should have received a copy of the GNU Affero General Public License 
+ * and its applicable Additional Terms for OBM along with this program. If not, 
+ * see <http://www.gnu.org/licenses/> for the GNU Affero General Public License version 3 
+ * and <http://www.linagora.com/licenses/> for the Additional Terms applicable to 
+ * OBM connectors. 
+ * 
+ * ***** END LICENSE BLOCK ***** */
+package com.lassekoskela.maven.timeline;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Date;
+
+import org.apache.maven.execution.ExecutionEvent;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecution;
+import org.codehaus.plexus.logging.console.ConsoleLogger;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.lassekoskela.maven.bean.Goal;
+import com.lassekoskela.maven.bean.Phase;
+import com.lassekoskela.maven.bean.Project;
+import com.lassekoskela.time.DateProvider;
+import com.lassekoskela.time.Duration;
+
+
+public class BuildTimelineListenerTest {
+
+	private BuildTimelineListener testee;
+	private DateProvider dateProvider;
+	private ExecutionEvent event;
+	private MavenSession session;
+	private MojoExecution execution;
+
+	@Before
+	public void setUp() {
+		dateProvider = mock(DateProvider.class);
+		event = mock(ExecutionEvent.class);
+		session = mock(MavenSession.class);
+		execution = mock(MojoExecution.class);
+		when(event.getSession()).thenReturn(session);
+		when(event.getMojoExecution()).thenReturn(execution);
+		
+		testee = new BuildTimelineListener(new ConsoleLogger(), dateProvider);
+	}
+	
+	@Test
+	public void testRelativeNowFromBuildStartTime() {
+		when(session.getStartTime()).thenReturn(new Date(1000l));
+		when(dateProvider.now()).thenReturn(new Date(1500l));
+		
+		assertThat(testee.relativeNowFromBuildStartTime(event), is(500l));
+	}
+	
+	@Test
+	public void testRelativeNowFromBuildStartTimeWhenSameDate() {
+		when(session.getStartTime()).thenReturn(new Date(1000l));
+		when(dateProvider.now()).thenReturn(new Date(1000l));
+		
+		assertThat(testee.relativeNowFromBuildStartTime(event), is(0l));
+	}
+	
+	@Test(expected=TimelineExportException.class)
+	public void testRelativeNowFromBuildStartTimeWhenLowerDate() {
+		when(session.getStartTime()).thenReturn(new Date(1000l));
+		when(dateProvider.now()).thenReturn(new Date(900l));
+		testee.relativeNowFromBuildStartTime(event);
+	}
+
+	@Test
+	public void testProjectOfMojoWhenEmpty() {
+		testee.projectOfMojo("project1");
+		
+		assertThat(testee.nameToProjectMapping, 
+				hasEntry("project1", new Project("project1", ImmutableSet.<Phase>of())));
+	}
+
+	@Test
+	public void testProjectOfMojoWhenContainsSameEntry() {
+		testee.projectOfMojo("project1");
+		testee.projectOfMojo("project1");
+		
+		assertThat(testee.nameToProjectMapping.size(), is(1));
+		assertThat(testee.nameToProjectMapping, 
+				hasEntry("project1", new Project("project1", ImmutableSet.<Phase>of())));
+	}
+
+	@Test
+	public void testProjectOfMojoWhenContainsAnotherEntry() {
+		testee.projectOfMojo("project1");
+		testee.projectOfMojo("project2");
+		
+		assertThat(testee.nameToProjectMapping, allOf(
+				hasEntry("project1", new Project("project1", ImmutableSet.<Phase>of())),
+				hasEntry("project2", new Project("project2", ImmutableSet.<Phase>of()))));
+	}
+
+	@Test(expected=NullPointerException.class)
+	public void testPhaseOfMojoWhenNullProject() {
+		Project project = null;
+		testee.phaseOfMojo("phase1", project);
+	}
+
+	@Test
+	public void testPhaseOfMojoWhenEmpty() {
+		Project project = new Project("project1", Sets.<Phase>newHashSet());
+		testee.phaseOfMojo("phase1", project);
+		
+		assertThat(project.getPhases(), 
+				contains(new Phase("phase1", ImmutableSet.<Goal>of())));
+	}
+
+	@Test
+	public void testPhaseOfMojoWhenContainsSameEntry() {
+		Project project = new Project("project1", Sets.<Phase>newHashSet());
+		testee.phaseOfMojo("phase1", project);
+		testee.phaseOfMojo("phase1", project);
+
+		assertThat(project.getPhases(), hasSize(1));
+		assertThat(project.getPhases(), contains(new Phase("phase1", ImmutableSet.<Goal>of())));
+	}
+
+	@Test
+	public void testPhaseOfMojoWhenContainsAnotherEntry() {
+		Project project = new Project("project1", Sets.<Phase>newHashSet());
+		testee.phaseOfMojo("phase1", project);
+		testee.phaseOfMojo("phase2", project);
+		
+		assertThat(project.getPhases(), contains(
+				new Phase("phase1", ImmutableSet.<Goal>of()),
+				new Phase("phase2", ImmutableSet.<Goal>of())));
+	}
+
+	@Test
+	public void testMojoStartedWhenEmpty() {
+		Phase phase = new Phase("phase1", Sets.<Goal>newHashSet());
+		Project project = new Project("project1", ImmutableSet.of(phase));
+		when(session.getStartTime()).thenReturn(new Date(1000l));
+		when(dateProvider.now()).thenReturn(new Date(1500l));
+		when(execution.getGoal()).thenReturn("goal1");
+		
+		testee.mojoStarted(event, project, phase);
+		
+		assertThat(phase.getGoals(), contains(
+				new Goal("goal1", new Duration(0), 500, ImmutableSet.<String>of())));
+	}
+
+	@Test
+	public void testMojoStartedWhenSameEntry() {
+		Phase phase = new Phase("phase1", Sets.<Goal>newHashSet());
+		Project project = new Project("project1", ImmutableSet.of(phase));
+		when(session.getStartTime()).thenReturn(new Date(1000l));
+		when(dateProvider.now()).thenReturn(new Date(1500l));
+		when(execution.getGoal()).thenReturn("goal1");
+		phase.addGoal(new Goal("goal1", new Duration(0), 500, ImmutableSet.<String>of()));
+		
+		testee.mojoStarted(event, project, phase);
+
+		assertThat(phase.getGoals(), hasSize(1));
+		assertThat(phase.getGoals(), contains(new Goal("goal1", new Duration(0), 500, ImmutableSet.<String>of())));
+	}
+
+	@Test
+	public void testMojoStartedWhenAnotherEntry() {
+		Phase phase = new Phase("phase1", Sets.<Goal>newHashSet());
+		Project project = new Project("project1", ImmutableSet.of(phase));
+		when(session.getStartTime()).thenReturn(new Date(1000l));
+		when(dateProvider.now()).thenReturn(new Date(1500l));
+		when(execution.getGoal()).thenReturn("goal1");
+		phase.addGoal(new Goal("goal0", new Duration(0), 500, ImmutableSet.<String>of()));
+		
+		testee.mojoStarted(event, project, phase);
+
+		assertThat(phase.getGoals(), contains(
+				new Goal("goal0", new Duration(0), 500, ImmutableSet.<String>of()),
+				new Goal("goal1", new Duration(0), 500, ImmutableSet.<String>of())));
+	}
+
+	@Test(expected=NullPointerException.class)
+	public void testMojoEndedWhenGoalNotStarted() {
+		when(execution.getGoal()).thenReturn("goal1");
+		
+		testee.mojoEnded(event);
+	}
+
+	@Test
+	public void testMojoEndedWhenGoalStarted() {
+		when(session.getStartTime()).thenReturn(new Date(1000l));
+		when(dateProvider.now()).thenReturn(new Date(1500l), new Date(2000l));
+		when(execution.getGoal()).thenReturn("goal1");
+		
+		Project project = testee.projectOfMojo("project1");
+		Phase phase = testee.phaseOfMojo("phase1", project);
+		testee.mojoStarted(event, project, phase);
+		
+		testee.mojoEnded(event);
+		
+		assertThat(phase.getGoals(), contains(
+				new Goal("goal1", new Duration(500), 500, ImmutableSet.<String>of())));
+	}
+}

--- a/src/test/java/com/lassekoskela/maven/timeline/ExporterTest.java
+++ b/src/test/java/com/lassekoskela/maven/timeline/ExporterTest.java
@@ -1,0 +1,161 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * 
+ * Copyright (C) 2011-2012  Linagora
+ *
+ * This program is free software: you can redistribute it and/or 
+ * modify it under the terms of the GNU Affero General Public License as 
+ * published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version, provided you comply 
+ * with the Additional Terms applicable for OBM connector by Linagora 
+ * pursuant to Section 7 of the GNU Affero General Public License, 
+ * subsections (b), (c), and (e), pursuant to which you must notably (i) retain 
+ * the “Message sent thanks to OBM, Free Communication by Linagora” 
+ * signature notice appended to any and all outbound messages 
+ * (notably e-mail and meeting requests), (ii) retain all hypertext links between 
+ * OBM and obm.org, as well as between Linagora and linagora.com, and (iii) refrain 
+ * from infringing Linagora intellectual property rights over its trademarks 
+ * and commercial brands. Other Additional Terms apply, 
+ * see <http://www.linagora.com/licenses/> for more details. 
+ *
+ * This program is distributed in the hope that it will be useful, 
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License 
+ * for more details. 
+ *
+ * You should have received a copy of the GNU Affero General Public License 
+ * and its applicable Additional Terms for OBM along with this program. If not, 
+ * see <http://www.gnu.org/licenses/> for the GNU Affero General Public License version 3 
+ * and <http://www.linagora.com/licenses/> for the Additional Terms applicable to 
+ * OBM connectors. 
+ * 
+ * ***** END LICENSE BLOCK ***** */
+package com.lassekoskela.maven.timeline;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import org.codehaus.plexus.logging.console.ConsoleLogger;
+import org.custommonkey.xmlunit.XMLAssert;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.lassekoskela.maven.bean.Goal;
+import com.lassekoskela.maven.bean.Phase;
+import com.lassekoskela.maven.bean.Project;
+import com.lassekoskela.maven.bean.Timeline;
+import com.lassekoskela.maven.timeline.GoalOrganizer.DisplayableGoal;
+import com.lassekoskela.time.Duration;
+
+public class ExporterTest {
+
+	private String filePath;
+	private Exporter exporter;
+
+	@Before
+	public void setUp() throws FileNotFoundException {
+		filePath = "timeline.html";
+		File exportFile = new File(filePath);
+		if (exportFile.exists() && exportFile.isDirectory()) {
+			for (File innerFile : exportFile.listFiles()) {
+				innerFile.delete();
+			}
+			exportFile.delete();
+		}
+		exporter = new Exporter(new ConsoleLogger());
+	}
+	
+	@Test(expected=NullPointerException.class)
+	public void testBuildItemModelOnNullGoal() {
+		DisplayableGoal goal = null;
+		exporter.buildItemModel(goal);
+	}
+	
+	@Test
+	public void testBuildItemModel() {
+		DisplayableGoal goal = new DisplayableGoal("project1", "phase1", "goal1", "dep1 dep2", 100, 200, 300);
+		
+		assertEquals(exporter.buildItemModel(goal),
+				ImmutableMap.of(
+						"projectId", "project1",
+						"phaseId", "phase1",
+						"goalId", "goal1",
+						"projectDeps", "dep1 dep2",
+						"cssStyle", "height:300px;top:200px;left:100px;"));
+	}
+	
+	@Test(expected=NullPointerException.class)
+	public void testBuildTimelineModelOnNull() {
+		exporter.buildTimelineModel(null);
+	}
+	
+	@Test
+	public void testBuildTimelineModel() {
+		assertEquals(exporter.buildTimelineModel("serializedTimeline"),
+				ImmutableMap.of("timeline", "serializedTimeline"));
+	}
+	
+	@Test
+	public void testGetExportFile() {
+		File exportFile = exporter.getExportFile(filePath);
+		assertFalse(exportFile.exists());
+	}
+
+	@Test
+	public void testGetExportFileWhenAlreadyExists() throws IOException {
+		File file = new File(filePath);
+		file.createNewFile();
+		assertTrue(file.exists());
+		
+		File exportFile = exporter.getExportFile(filePath);
+		
+		assertFalse(exportFile.exists());
+	}
+	
+	@Test(expected=TimelineExportException.class)
+	public void testGetExportFileWhenAlreadyExistsAsNonEmptyDirectory() throws Exception {
+		File directory = new File(filePath);
+		directory.mkdir();
+		new File(directory, "child.txt").createNewFile();
+		
+		exporter.export(new Timeline(ImmutableSet.<Project>of()));
+	}
+	
+	@Test
+	public void testExportTimelineTwoProjects() throws Exception {
+		Timeline timeline = new Timeline(ImmutableSet.of(
+			new Project("project1", ImmutableSet.of(
+				new Phase("validate", ImmutableSet.of(
+						new Goal("goal0", new Duration(2000), 0, ImmutableSet.<String>of()),
+						new Goal("goal1", new Duration(80000), 2800, ImmutableSet.of("project1-validate-goal0")),
+						new Goal("goal2", new Duration(40000), 85000, ImmutableSet.of("project1-validate-goal0 project1-validate-goal1")))),
+				new Phase("compile", ImmutableSet.of(
+						new Goal("goal1", new Duration(12000), 0, ImmutableSet.<String>of()),
+						new Goal("goal2", new Duration(100000), 20000, ImmutableSet.of("project1-validate-goal0", "project1-compile-goal1")))))),
+			new Project("project2", ImmutableSet.of(
+				new Phase("test", ImmutableSet.of(
+						new Goal("goal1", new Duration(2000), 83000, ImmutableSet.<String>of()),
+						new Goal("goal2", new Duration(8000), 86000, ImmutableSet.of("project2-test-goal1")))),
+				new Phase("install", ImmutableSet.of(
+						new Goal("goal1", new Duration(12000), 30000, ImmutableSet.of("project2-install-goal2", "project2-test-goal2")),
+						new Goal("goal2", new Duration(4000), 28000, ImmutableSet.<String>of())))))));
+		
+		File htmlFile = exporter.export(timeline);
+		
+		Document htmlDoc = XMLUnit.buildControlDocument(new InputSource(new FileInputStream(htmlFile)));
+		Document expectedHtmlDoc = XMLUnit.buildTestDocument(new InputSource(ClassLoader.getSystemResourceAsStream("timeline_two_projects.html")));
+		
+		XMLUnit.setIgnoreWhitespace(true);
+		XMLAssert.assertXMLEqual(htmlDoc, expectedHtmlDoc);
+	}
+}

--- a/src/test/java/com/lassekoskela/maven/timeline/ExporterTest.java
+++ b/src/test/java/com/lassekoskela/maven/timeline/ExporterTest.java
@@ -1,34 +1,3 @@
-/* ***** BEGIN LICENSE BLOCK *****
- * 
- * Copyright (C) 2011-2012  Linagora
- *
- * This program is free software: you can redistribute it and/or 
- * modify it under the terms of the GNU Affero General Public License as 
- * published by the Free Software Foundation, either version 3 of the 
- * License, or (at your option) any later version, provided you comply 
- * with the Additional Terms applicable for OBM connector by Linagora 
- * pursuant to Section 7 of the GNU Affero General Public License, 
- * subsections (b), (c), and (e), pursuant to which you must notably (i) retain 
- * the “Message sent thanks to OBM, Free Communication by Linagora” 
- * signature notice appended to any and all outbound messages 
- * (notably e-mail and meeting requests), (ii) retain all hypertext links between 
- * OBM and obm.org, as well as between Linagora and linagora.com, and (iii) refrain 
- * from infringing Linagora intellectual property rights over its trademarks 
- * and commercial brands. Other Additional Terms apply, 
- * see <http://www.linagora.com/licenses/> for more details. 
- *
- * This program is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
- * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License 
- * for more details. 
- *
- * You should have received a copy of the GNU Affero General Public License 
- * and its applicable Additional Terms for OBM along with this program. If not, 
- * see <http://www.gnu.org/licenses/> for the GNU Affero General Public License version 3 
- * and <http://www.linagora.com/licenses/> for the Additional Terms applicable to 
- * OBM connectors. 
- * 
- * ***** END LICENSE BLOCK ***** */
 package com.lassekoskela.maven.timeline;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/lassekoskela/maven/timeline/GoalOrganizerTest.java
+++ b/src/test/java/com/lassekoskela/maven/timeline/GoalOrganizerTest.java
@@ -1,0 +1,298 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * 
+ * Copyright (C) 2011-2012  Linagora
+ *
+ * This program is free software: you can redistribute it and/or 
+ * modify it under the terms of the GNU Affero General Public License as 
+ * published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version, provided you comply 
+ * with the Additional Terms applicable for OBM connector by Linagora 
+ * pursuant to Section 7 of the GNU Affero General Public License, 
+ * subsections (b), (c), and (e), pursuant to which you must notably (i) retain 
+ * the “Message sent thanks to OBM, Free Communication by Linagora” 
+ * signature notice appended to any and all outbound messages 
+ * (notably e-mail and meeting requests), (ii) retain all hypertext links between 
+ * OBM and obm.org, as well as between Linagora and linagora.com, and (iii) refrain 
+ * from infringing Linagora intellectual property rights over its trademarks 
+ * and commercial brands. Other Additional Terms apply, 
+ * see <http://www.linagora.com/licenses/> for more details. 
+ *
+ * This program is distributed in the hope that it will be useful, 
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License 
+ * for more details. 
+ *
+ * You should have received a copy of the GNU Affero General Public License 
+ * and its applicable Additional Terms for OBM along with this program. If not, 
+ * see <http://www.gnu.org/licenses/> for the GNU Affero General Public License version 3 
+ * and <http://www.linagora.com/licenses/> for the Additional Terms applicable to 
+ * OBM connectors. 
+ * 
+ * ***** END LICENSE BLOCK ***** */
+package com.lassekoskela.maven.timeline;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Comparator;
+import java.util.SortedSet;
+
+import org.codehaus.plexus.logging.console.ConsoleLogger;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
+import com.lassekoskela.maven.bean.Goal;
+import com.lassekoskela.maven.bean.Phase;
+import com.lassekoskela.maven.bean.Project;
+import com.lassekoskela.maven.bean.Timeline;
+import com.lassekoskela.maven.timeline.GoalOrganizer.Columns;
+import com.lassekoskela.maven.timeline.GoalOrganizer.DisplayableGoal;
+import com.lassekoskela.maven.timeline.GoalOrganizer.SortedGoal;
+import com.lassekoskela.time.Duration;
+
+
+public class GoalOrganizerTest {
+
+	
+	
+	private ConsoleLogger logger;
+	private GoalOrganizer testee;
+
+	@Before
+	public void setUp() {
+		logger = new ConsoleLogger();
+		testee = new GoalOrganizer(logger);
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void testColumnToLeftPositionWhenNegative() {
+		testee.columnToLeftPosition(-1);
+	}
+	
+	@Test
+	public void testColumnToLeftPositionWhenZero() {
+		assertThat(testee.columnToLeftPosition(0), is(0L));
+	}
+	
+	@Test
+	public void testColumnToLeftPositionWhenOne() {
+		assertThat(testee.columnToLeftPosition(1), is(60L));
+	}
+	
+	@Test
+	public void testColumnToLeftPositionWhenThousand() {
+		assertThat(testee.columnToLeftPosition(1000), is(60000L));
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void testVerticalValueWhenNegative() {
+		testee.verticalValue(-1l);
+	}
+	
+	@Test
+	public void testVerticalValueWhenZero() {
+		assertThat(testee.verticalValue(0l), is(0L));
+	}
+
+	@Test
+	public void testVerticalValueWhenCloseToOneSecond() {
+		assertThat(testee.verticalValue(900l), is(4L));
+	}
+
+	@Test
+	public void testVerticalValueWhenAlmostToOneSecond() {
+		assertThat(testee.verticalValue(1100l), is(5L));
+	}
+
+	@Test
+	public void testVerticalValueWhenOneSecond() {
+		assertThat(testee.verticalValue(1000l), is(4L));
+	}
+
+	@Test
+	public void testVerticalValueWhenOneHour() {
+		assertThat(testee.verticalValue(1000l * 60 * 60), is(14400L));
+	}
+	
+	@Test
+	public void testBuildMinimalDisplayableGoal() {
+		Columns columnOfGoals = new Columns();
+		Project project = new Project("project1", ImmutableSet.<Phase>of());
+		Phase phase = new Phase("phase1", ImmutableSet.<Goal>of());
+		Goal goal = new Goal("goal1", new Duration(0), 0, ImmutableSet.<String>of());
+		SortedGoal sortedGoal = new SortedGoal(project, phase, goal);
+
+		assertThat(testee.buildDisplayableGoal(columnOfGoals, sortedGoal), is(
+				new DisplayableGoal("project1", "phase1", "goal1", "", 0, 0, 0)));
+	}
+	
+	@Test
+	public void testBuildFirstDisplayableGoal() {
+		Columns columnOfGoals = new Columns();
+		Project project = new Project("project1", ImmutableSet.<Phase>of());
+		Phase phase = new Phase("phase1", ImmutableSet.<Goal>of());
+		Goal goal = new Goal("goal1", new Duration(2000), 1000, ImmutableSet.of("dep1", "dep2"));
+		SortedGoal sortedGoal = new SortedGoal(project, phase, goal);
+
+		assertThat(testee.buildDisplayableGoal(columnOfGoals, sortedGoal), is(
+				new DisplayableGoal("project1", "phase1", "goal1", "dep1 dep2", 0, 4, 8)));
+	}
+	
+	@Test
+	public void testBuildSecondDisplayableGoalWhenFittingFirstColumn() {
+		Columns columnOfGoals = new Columns();
+		columnOfGoals.addGoal(new Goal("goal1", new Duration(2000), 1000, ImmutableSet.<String>of()));
+		
+		Project project = new Project("project1", ImmutableSet.<Phase>of());
+		Phase phase = new Phase("phase1", ImmutableSet.<Goal>of());
+		Goal goal = new Goal("goal1", new Duration(8000), 4000, ImmutableSet.of("dep1", "dep2"));
+		SortedGoal sortedGoal = new SortedGoal(project, phase, goal);
+
+		assertThat(testee.buildDisplayableGoal(columnOfGoals, sortedGoal), is(
+				new DisplayableGoal("project1", "phase1", "goal1", "dep1 dep2", 0, 16, 32)));
+	}
+	
+	@Test
+	public void testBuildSecondDisplayableGoalWhenNotFittingFirstColumn() {
+		Columns columnOfGoals = new Columns();
+		columnOfGoals.addGoal(new Goal("goal1", new Duration(2000), 1000, ImmutableSet.<String>of()));
+		
+		Project project = new Project("project1", ImmutableSet.<Phase>of());
+		Phase phase = new Phase("phase1", ImmutableSet.<Goal>of());
+		Goal goal = new Goal("goal1", new Duration(2000), 2000, ImmutableSet.of("dep1", "dep2"));
+		SortedGoal sortedGoal = new SortedGoal(project, phase, goal);
+
+		assertThat(testee.buildDisplayableGoal(columnOfGoals, sortedGoal), is(
+				new DisplayableGoal("project1", "phase1", "goal1", "dep1 dep2", 60, 8, 8)));
+	}
+	
+	@Test
+	public void testGoalStartTimeComparatorFirstEarlier() {
+		Comparator<SortedGoal> goalStartTimeComparator = testee.newGoalStartTimeComparator();
+		SortedGoal goal1 = new SortedGoal(null, null, new Goal("g1", new Duration(0), 0, ImmutableSet.<String>of()));
+		SortedGoal goal2 = new SortedGoal(null, null, new Goal("g1", new Duration(0), 100, ImmutableSet.<String>of()));
+
+		assertThat(goalStartTimeComparator.compare(goal1, goal2), is(-1));
+	}
+	
+	@Test
+	public void testGoalStartTimeComparatorFirstLater() {
+		Comparator<SortedGoal> goalStartTimeComparator = testee.newGoalStartTimeComparator();
+		SortedGoal goal1 = new SortedGoal(null, null, new Goal("g1", new Duration(0), 100, ImmutableSet.<String>of()));
+		SortedGoal goal2 = new SortedGoal(null, null, new Goal("g1", new Duration(0), 0, ImmutableSet.<String>of()));
+
+		assertThat(goalStartTimeComparator.compare(goal1, goal2), is(1));
+	}
+
+	@Test
+	public void testGoalStartTimeComparatorBothZero() {
+		Comparator<SortedGoal> goalStartTimeComparator = testee.newGoalStartTimeComparator();
+		SortedGoal goal1 = new SortedGoal(null, null, new Goal("g1", new Duration(0), 0, ImmutableSet.<String>of()));
+		SortedGoal goal2 = new SortedGoal(null, null, new Goal("g1", new Duration(0), 0, ImmutableSet.<String>of()));
+
+		assertThat(goalStartTimeComparator.compare(goal1, goal2), is(0));		
+	}
+	
+	@Test
+	public void testGoalStartTimeComparatorTakeDurationWhenSameStartTime() {
+		Comparator<SortedGoal> goalStartTimeComparator = testee.newGoalStartTimeComparator();
+		SortedGoal goal1 = new SortedGoal(null, null, new Goal("g1", new Duration(100), 0, ImmutableSet.<String>of()));
+		SortedGoal goal2 = new SortedGoal(null, null, new Goal("g1", new Duration(200), 0, ImmutableSet.<String>of()));
+
+		assertThat(goalStartTimeComparator.compare(goal1, goal2), is(-1));
+	}
+	
+	@Test
+	public void testGoalStartTimeComparatorTakeDurationWhenSameStartTimeSecond() {
+		Comparator<SortedGoal> goalStartTimeComparator = testee.newGoalStartTimeComparator();
+		SortedGoal goal1 = new SortedGoal(null, null, new Goal("g1", new Duration(300), 0, ImmutableSet.<String>of()));
+		SortedGoal goal2 = new SortedGoal(null, null, new Goal("g1", new Duration(200), 0, ImmutableSet.<String>of()));
+
+		assertThat(goalStartTimeComparator.compare(goal1, goal2), is(1));
+	}
+	
+	@Test
+	public void testGoalStartTimeComparator() {
+		SortedSet<SortedGoal> goals = ImmutableSortedSet.orderedBy(testee.newGoalStartTimeComparator())
+			.add(new SortedGoal(null, null, new Goal("g1", new Duration(300), 100, ImmutableSet.<String>of())))
+			.add(new SortedGoal(null, null, new Goal("g2", new Duration(200), 100, ImmutableSet.<String>of())))
+			.add(new SortedGoal(null, null, new Goal("g3", new Duration(400), 100, ImmutableSet.<String>of())))
+			.add(new SortedGoal(null, null, new Goal("g4", new Duration(50), 40, ImmutableSet.<String>of())))
+			.add(new SortedGoal(null, null, new Goal("g5", new Duration(60), 40, ImmutableSet.<String>of())))
+			.add(new SortedGoal(null, null, new Goal("g6", new Duration(40), 60, ImmutableSet.<String>of())))
+			.build();
+
+		assertThat(goals, contains(
+				new SortedGoal(null, null, new Goal("g4", new Duration(50), 40, ImmutableSet.<String>of())),
+				new SortedGoal(null, null, new Goal("g5", new Duration(60), 40, ImmutableSet.<String>of())),
+				new SortedGoal(null, null, new Goal("g6", new Duration(40), 60, ImmutableSet.<String>of())),
+				new SortedGoal(null, null, new Goal("g2", new Duration(200), 100, ImmutableSet.<String>of())),
+				new SortedGoal(null, null, new Goal("g1", new Duration(300), 100, ImmutableSet.<String>of())),
+				new SortedGoal(null, null, new Goal("g3", new Duration(400), 100, ImmutableSet.<String>of()))));
+		
+	}
+	
+	@Test
+	public void testOrganizeTimelineTwoProjects() throws Exception {
+		Timeline timeline = new Timeline(ImmutableSet.of(
+			new Project("project1", ImmutableSet.of(
+				new Phase("phase1", ImmutableSet.of(
+						new Goal("goal1", new Duration(800), 0, ImmutableSet.<String>of()),
+						new Goal("goal3", new Duration(0), 400, ImmutableSet.<String>of()),
+						new Goal("goal2", new Duration(400), 0, ImmutableSet.<String>of()))),
+				new Phase("phase2", ImmutableSet.of(
+						new Goal("goal1", new Duration(1200), 1000, ImmutableSet.of("project1-phase1-goal1")),
+						new Goal("goal2", new Duration(2400), 2000, ImmutableSet.of("project1-phase1-goal1", "project1-phase1-goal2")))))),
+			new Project("project2", ImmutableSet.of(
+				new Phase("phase1", ImmutableSet.of(
+						new Goal("goal1", new Duration(200), 5500, ImmutableSet.<String>of()),
+						new Goal("goal2", new Duration(400), 15000, ImmutableSet.of("project2-phase1-goal1")))),
+				new Phase("phase2", ImmutableSet.of(
+						new Goal("goal1", new Duration(1200), 30000, ImmutableSet.of("project2-phase2-goal2", "project2-phase1-goal2")),
+						new Goal("goal2", new Duration(400), 28000, ImmutableSet.<String>of())))))));
+		
+		assertThat(testee.organize(timeline), contains(
+				new DisplayableGoal("project1", "phase1", "goal2", "", 0, 0, 2),
+				new DisplayableGoal("project1", "phase1", "goal1", "", 60, 0, 4),
+				new DisplayableGoal("project1", "phase1", "goal3", "", 0, 2, 0),
+				new DisplayableGoal("project1", "phase2", "goal1", "project1-phase1-goal1", 0, 4, 5),
+				new DisplayableGoal("project1", "phase2", "goal2", "project1-phase1-goal1 project1-phase1-goal2", 60, 8, 10),
+				new DisplayableGoal("project2", "phase1", "goal1", "", 0, 22, 1),
+				new DisplayableGoal("project2", "phase1", "goal2", "project2-phase1-goal1", 60, 60, 2),
+				new DisplayableGoal("project2", "phase2", "goal2", "", 0, 112, 2),
+				new DisplayableGoal("project2", "phase2", "goal1", "project2-phase2-goal2 project2-phase1-goal2", 60, 120, 5)
+		));
+	}
+
+	@Test
+	public void testOrganizeTimelineWhenTwoGoalsHaveSameCompletedTime() throws Exception {
+		Timeline timeline = new Timeline(ImmutableSet.of(
+			new Project("parent", ImmutableSet.of(
+				new Phase("clean", ImmutableSet.of(
+						new Goal("clean", new Duration(191), 1231, ImmutableSet.<String>of()))),
+				new Phase("install", ImmutableSet.of(
+						new Goal("install", new Duration(144), 1300, ImmutableSet.<String>of()))))),
+			new Project("technical-log-bean", ImmutableSet.of(
+				new Phase("clean", ImmutableSet.of(
+						new Goal("clean", new Duration(6), 1473, ImmutableSet.<String>of()))),
+				new Phase("process-resources", ImmutableSet.of(
+						new Goal("resources", new Duration(0), 1479, ImmutableSet.<String>of()))))),
+			new Project("common-test", ImmutableSet.of(
+					new Phase("clean", ImmutableSet.of(
+							new Goal("clean", new Duration(87), 1514, ImmutableSet.<String>of()))),
+					new Phase("process-resources", ImmutableSet.of(
+							new Goal("resources", new Duration(16), 1601, ImmutableSet.<String>of())))))));
+
+		assertThat(testee.organize(timeline), contains(
+				new DisplayableGoal("parent", "clean", "clean", "", 0, 5, 1),
+				new DisplayableGoal("parent", "install", "install", "", 60, 6, 1),
+				new DisplayableGoal("technical-log-bean", "clean", "clean", "", 0, 6, 1),
+				new DisplayableGoal("technical-log-bean", "process-resources", "resources", "", 60, 6, 0),
+				new DisplayableGoal("common-test", "clean", "clean", "", 0, 7, 1),
+				new DisplayableGoal("common-test", "process-resources", "resources", "", 60, 7, 1)
+		));
+	}
+}

--- a/src/test/java/com/lassekoskela/maven/timeline/GoalOrganizerTest.java
+++ b/src/test/java/com/lassekoskela/maven/timeline/GoalOrganizerTest.java
@@ -1,34 +1,3 @@
-/* ***** BEGIN LICENSE BLOCK *****
- * 
- * Copyright (C) 2011-2012  Linagora
- *
- * This program is free software: you can redistribute it and/or 
- * modify it under the terms of the GNU Affero General Public License as 
- * published by the Free Software Foundation, either version 3 of the 
- * License, or (at your option) any later version, provided you comply 
- * with the Additional Terms applicable for OBM connector by Linagora 
- * pursuant to Section 7 of the GNU Affero General Public License, 
- * subsections (b), (c), and (e), pursuant to which you must notably (i) retain 
- * the “Message sent thanks to OBM, Free Communication by Linagora” 
- * signature notice appended to any and all outbound messages 
- * (notably e-mail and meeting requests), (ii) retain all hypertext links between 
- * OBM and obm.org, as well as between Linagora and linagora.com, and (iii) refrain 
- * from infringing Linagora intellectual property rights over its trademarks 
- * and commercial brands. Other Additional Terms apply, 
- * see <http://www.linagora.com/licenses/> for more details. 
- *
- * This program is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
- * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License 
- * for more details. 
- *
- * You should have received a copy of the GNU Affero General Public License 
- * and its applicable Additional Terms for OBM along with this program. If not, 
- * see <http://www.gnu.org/licenses/> for the GNU Affero General Public License version 3 
- * and <http://www.linagora.com/licenses/> for the Additional Terms applicable to 
- * OBM connectors. 
- * 
- * ***** END LICENSE BLOCK ***** */
 package com.lassekoskela.maven.timeline;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/resources/timeline_two_projects.html
+++ b/src/test/resources/timeline_two_projects.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<META http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+		<title>Your Maven build</title>
+		<style type="text/css">
+			body {
+				border-top: red 2px solid;
+				border-left: red 2px solid;
+				padding: 10px;
+				position: relative;
+				min-height: 600px;
+			}
+			.build-item {
+				position: absolute;
+				width: 50px;
+				font-size: 20px;
+				letter-spacing: 20px;
+				line-height: 100%;
+				text-align: center;
+				word-wrap: break-word;
+				overflow: hidden;
+				-moz-border-radius: 5px;
+				border-radius: 5px;
+				opacity:0.85;
+				background-color: lightGray;
+			}
+			.build-item:hover {
+				box-shadow: 0px 0px 0px 2px black;
+				opacity:1;
+			}
+			.build-item-selected {
+				box-shadow: 0px 0px 0px 1px black;
+				opacity:1;
+			}
+			.build-item-highlight {
+				box-shadow: 0px 0px 0px 1px red;
+				opacity:1;
+			}
+			.build-item-pre-clean {
+				background-color: #CCA300;
+			}
+			.build-item-clean {
+				background-color: #FFCC00;
+			}
+			.build-item-post-clean {
+				background-color: #FFD633;
+			}
+			.build-item-validate {
+				background-color: #3366CC;
+			}
+			.build-item-initialize {
+				background-color: #5C85D6;
+			}
+			.build-item-generate-sources {
+				background-color: #0099CC;
+			}
+			.build-item-process-sources {
+				background-color: #33ADD6
+			}
+			.build-item-generate-resources {
+				background-color: #33CCCC
+			}
+			.build-item-process-resources {
+				background-color: #5CD6D6
+			}
+			.build-item-compile {
+				background-color: #00FFCC
+			}
+			.build-item-process-classes {
+				background-color: #33FFD6
+			}
+			.build-item-generate-test-sources {
+				background-color: #00FF99
+			}
+			.build-item-process-test-sources {
+				background-color: #33FFAD
+			}
+			.build-item-generate-test-resources {
+				background-color: #00B200
+			}
+			.build-item-process-test-resources {
+				background-color: #00E600
+			}
+			.build-item-test-compile {
+				background-color: #33CC33
+			}
+			.build-item-process-test-classes {
+				background-color: #5CD65C
+			}
+			.build-item-test {
+				background-color: #19A319
+			}
+			.build-item-prepare-package {
+				background-color: #4DB84D
+			}
+			.build-item-package {
+				background-color: #47A375
+			}
+			.build-item-pre-integration-test {
+				background-color: #70B894
+			}
+			.build-item-integration-test {
+				background-color: #99CCB2
+			}
+			.build-item-post-integration-test {
+				background-color: #C2E0D1
+			}
+			.build-item-verify {
+				background-color: #AD33AD
+			}
+			.build-item-install {
+				background-color: #C266C2
+			}
+			.build-item-deploy {
+				background-color: #D699D6
+			}
+		</style>
+	</head>
+	<body>
+	
+		<div class="build-item build-item-validate" data-deps="" id="project1-validate-goal0" onclick="buildItemClicked(this)" style="height:8px;top:0px;left:0px;" title="project1 (validate:goal0)">
+			project1</div>
+
+		
+		<div class="build-item build-item-compile" data-deps="" id="project1-compile-goal1" onclick="buildItemClicked(this)" style="height:48px;top:0px;left:60px;" title="project1 (compile:goal1)">
+					project1</div>
+		
+		
+		<div class="build-item build-item-validate" data-deps="project1-validate-goal0" id="project1-validate-goal1" onclick="buildItemClicked(this)" style="height:320px;top:12px;left:0px;" title="project1 (validate:goal1)">
+					project1</div>
+		
+		
+		<div class="build-item build-item-compile" data-deps="project1-validate-goal0 project1-compile-goal1" id="project1-compile-goal2" onclick="buildItemClicked(this)" style="height:400px;top:80px;left:60px;" title="project1 (compile:goal2)">
+					project1</div>
+		
+		
+		<div class="build-item build-item-install" data-deps="" id="project2-install-goal2" onclick="buildItemClicked(this)" style="height:16px;top:112px;left:120px;" title="project2 (install:goal2)">
+					project2</div>
+		
+		
+		<div class="build-item build-item-install" data-deps="project2-install-goal2 project2-test-goal2" id="project2-install-goal1" onclick="buildItemClicked(this)" style="height:48px;top:120px;left:180px;" title="project2 (install:goal1)">
+					project2</div>
+		
+		
+		<div class="build-item build-item-test" data-deps="" id="project2-test-goal1" onclick="buildItemClicked(this)" style="height:8px;top:332px;left:120px;" title="project2 (test:goal1)">
+					project2</div>
+		
+		
+		<div class="build-item build-item-validate" data-deps="project1-validate-goal0 project1-validate-goal1" id="project1-validate-goal2" onclick="buildItemClicked(this)" style="height:160px;top:340px;left:180px;" title="project1 (validate:goal2)">
+					project1</div>
+		
+		
+		<div class="build-item build-item-test" data-deps="project2-test-goal1" id="project2-test-goal2" onclick="buildItemClicked(this)" style="height:32px;top:344px;left:0px;" title="project2 (test:goal2)">
+					project2</div>
+
+		<script type="text/javascript">
+
+			var selectedBuildItem = null;
+			var highlightedBuildItems = [];
+
+			function buildItemClicked(buildItem) {
+				removeHighlights();
+				changeSelectedBuildItem(buildItem);
+				addHighlights(buildItem);
+			}
+
+			function addHighlights(buildItem) {
+				buildItem.dataset.deps.split(" ").forEach(function(dependencyId) {
+					if (dependencyId == "") {
+						return;
+					}
+					var dependencyElement = document.getElementById(dependencyId);
+					highlightedBuildItems.push(dependencyId);
+					dependencyElement.classList.add("build-item-highlight");
+				});
+			}
+
+			function changeSelectedBuildItem(newSelectedBuildItem) {
+				if (selectedBuildItem != null) {
+					selectedBuildItem.classList.remove("build-item-selected");
+				}
+				newSelectedBuildItem.classList.add("build-item-selected");
+				selectedBuildItem = newSelectedBuildItem;
+			}
+
+			function removeHighlights() {
+				highlightedBuildItems.forEach(function(dependencyId) {
+					document.getElementById(dependencyId).classList.remove("build-item-highlight");
+				});
+				highlightedBuildItems = [];
+			}
+		</script>
+	</body>
+</html>

--- a/src/test/resources/timeline_two_projects.html
+++ b/src/test/resources/timeline_two_projects.html
@@ -6,7 +6,6 @@
 		<style type="text/css">
 			body {
 				border-top: red 2px solid;
-				border-left: red 2px solid;
 				padding: 10px;
 				position: relative;
 				min-height: 600px;


### PR DESCRIPTION
Hi,

I implemented a new feature for your plugin which export a view of the maven build as a html page. This feature is really interresting for longs builds, it permits to see the theirs parallelism degree. 

This feature is useless for shorts build, but we schedule a next step which is to customize the scale value for the time axe. There is also an highlight system for dependencies implemented in the HTML page, but datas are not filled yet.

This feature can be activated by using this profile :

``` xml
<profile>
   <id>timeline</id>
   <properties>
      <maven-build-utils.activate-timeline>true</maven-build-utils.activate-timeline>
   </properties>
</profile>
```

When the build is done, you can reach the picture with 

``` bash
iceweasel timeline.html
```

Thanks !
